### PR TITLE
Restore the 2.3 editions of Notebooks so they show up on Colab

### DIFF
--- a/notebooks/demo_notebooks/RIME_Adversarial_NLP_Walkthrough.ipynb
+++ b/notebooks/demo_notebooks/RIME_Adversarial_NLP_Walkthrough.ipynb
@@ -1,0 +1,449 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "dd9c562c",
+   "metadata": {},
+   "source": [
+    "# **RI Adversarial NLP Walkthrough**\n",
+    "\n",
+    "> ▶️ **Try this in Colab!** Run the [RI Adversarial NLP Walkthrough in Google Colab](https://colab.research.google.com/github/RobustIntelligence/docs/blob/main/notebooks/demo_notebooks/RIME_Adversarial_NLP_Walkthrough.ipynb). \n",
+    "\n",
+    "You are the AI Risk Officer at a Consumer Social Company. The NLP team has been tasked with implementing a text classification model to predict the top-level \"sentiment\" of posts on the app. These predictions will later be consumed by multiple models throughout the company, such as recommendation, lead prediction, and the core advertisement models. You want to verify your models are sufficiently robust to adversaries seeking to exploit model vulnerabilities and boost content that your user base does not actually like.\n",
+    "\n",
+    "In this Notebook Walkthrough, we will review our core product of **AI Stress Testing** of NLP models in an *adversarial setting*. RIME AI Stress Testing allows you to test any text classification model on any dataset. In this way, you will be able to quantify your model's vulnerability to attacks and noisy data.\n",
+    "\n",
+    "Your team's NLP models are fine-tuned from state-of-the-art transformer models found on [Hugging Face's Model Hub 🤗](https://huggingface.co/models). In particular, you have chosen to fine-tune a [DistilBERT](https://huggingface.co/distilbert-base-uncased-finetuned-sst-2-english) on data similar to the [Stanford Sentiment Treebank](https://huggingface.co/datasets/sst2) dataset for a lightweight yet performant model. \n",
+    "\n",
+    "For more information on how to connect with a [Hugging Face Model](https://readthedocs.com/cas/login?service=https%3A%2F%2Frobust-intelligence-inc-rime.readthedocs-hosted.com%2Fen%2Flatest%2Ffor_data_scientists%2Fhow_to_guides%2Fintegrations%2Fhuggingface.html%3Fnext%3Dhttps%253A%252F%252Frobust-intelligence-inc-rime.readthedocs-hosted.com%252Fen%252Flatest%252Ffor_data_scientists%252Fhow_to_guides%252Fintegrations%252Fhuggingface.html%253Fhighlight%253Dhuggingface#huggingface-classification-model) or \n",
+    "[Hugging Face Dataset](https://readthedocs.com/cas/login?service=https%3A%2F%2Frobust-intelligence-inc-rime.readthedocs-hosted.com%2Fen%2Flatest%2Ffor_data_scientists%2Freference%2Fconfiguration%2Fnlp%2Fdata_source.html%3Fnext%3Dhttps%253A%252F%252Frobust-intelligence-inc-rime.readthedocs-hosted.com%252Fen%252Flatest%252Ffor_data_scientists%252Freference%252Fconfiguration%252Fnlp%252Fdata_source.html%253Fhighlight%253Dhuggingface#huggingface-dataset), check out the linked documentation.\n",
+    "\n",
+    "To begin, please specify your RIME cluster's URL and personal access token."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d28e7fdf-4155-4130-95e0-07825beb28c0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install rime-sdk &> /dev/null\n",
+    "!pip install seaborn\n",
+    "\n",
+    "from rime_sdk import Client"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "955fb070-7b37-4288-99a5-ea5967b6028b",
+   "metadata": {
+    "id": "90zo7hdkmKyW",
+    "tags": []
+   },
+   "source": [
+    "## **Establish the RIME Client**\n",
+    "\n",
+    "To get started, provide the API credentials and the base domain/address of the RIME service. You can generate and copy an API token from the API Access Tokens Page under Workspace settings. For the domian/address of the RIME service, contact your admin. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "60a0e5b1-2f69-4819-a9c8-5455c3848e7f",
+   "metadata": {
+    "id": "90zo7hdkmKyW"
+   },
+   "source": [
+    "![img_1](https://drive.google.com/uc?id=1vMDhZii8yq22iuqSM8-Vqt3sZ2F3tPyz)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dd6b3853-b365-4444-b629-3bc8b36f4cf8",
+   "metadata": {
+    "id": "Ns6m8I-qsCzF"
+   },
+   "outputs": [],
+   "source": [
+    "API_TOKEN = '' # PASTE API_KEY \n",
+    "CLUSTER_URL = '' # PASTE DEDICATED DOMAIN OF RIME SERVICE (eg: rime.stable.rbst.io)\n",
+    "AGENT_ID = '' # PASTE AGENT_ID IF USING AN AGENT THAT IS NOT THE DEFAULT"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2763391c-f37e-464d-b14e-556e9e95d0b3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "client = Client(CLUSTER_URL, API_TOKEN)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "81130477-0c7d-4dd0-88cf-3d39f96d8079",
+   "metadata": {},
+   "source": [
+    "## **Create a Project**\n",
+    "\n",
+    "Below, create a project to store this and other future adversarial robustness stress test run results."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "72059347",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "description = (\n",
+    "    \"Evaluate the robustness of text classification models\"\n",
+    "    \" against adversarial attacks. Demonstration uses the\"\n",
+    "    \" SST-2 dataset (https://huggingface.co/datasets/sst2)\"\n",
+    "    \" and a fine-tuned version of the DistilBERT model\"\n",
+    "    \" (https://huggingface.co/distilbert-base-uncased-finetuned-sst-2-english).\"\n",
+    ")\n",
+    "project = client.create_project(\n",
+    "    name=\"NLP Adversarial Robustness Demo\", \n",
+    "    description=description,\n",
+    "    model_task=\"MODEL_TASK_MULTICLASS_CLASSIFICATION\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "74a10ae5-cf42-4c0e-b8fa-741488a9bb86",
+   "metadata": {},
+   "source": [
+    "## **Register Model and Datasets**\n",
+    "\n",
+    "Next, we use datasets (Stanford Sentiment Treebank) and model (DistilBERT) from huggingface, as described abov, and register those with RIME."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2f1994b6-d07c-4f7b-bfa7-0e06585f3f9f",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "from datetime import datetime\n",
+    "\n",
+    "dt = str(datetime.now())\n",
+    "model_id = project.register_model(\n",
+    "    f'model_{dt}',\n",
+    "    model_config={\n",
+    "        \"hugging_face\": {\n",
+    "            \"model_uri\": \"distilbert-base-uncased-finetuned-sst-2-english\"\n",
+    "        }\n",
+    "    },\n",
+    "    agent_id=AGENT_ID\n",
+    ")\n",
+    "def _register_dataset(split_name):\n",
+    "    data_info = {\n",
+    "        \"connection_info\": {\n",
+    "            \"hugging_face\": {\n",
+    "                \"dataset_uri\": \"sst2\",\n",
+    "                \"split_name\": split_name,\n",
+    "            },\n",
+    "        },\n",
+    "        \"data_params\": {\n",
+    "            \"label_col\": \"label\",\n",
+    "            \"text_features\": [\"sentence\"],\n",
+    "            \"sample\": True,\n",
+    "            \"nrows\": 100\n",
+    "        },\n",
+    "    }\n",
+    "    return project.register_dataset(f'{split_name}_datset_{dt}', data_info, agent_id=AGENT_ID)\n",
+    "\n",
+    "\n",
+    "ref_dataset_id = _register_dataset(\"train\")\n",
+    "eval_dataset_id = _register_dataset(\"validation\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5b114e9c",
+   "metadata": {},
+   "source": [
+    "## **Start File Scan on the Registered Model**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "221fc7e0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "file_scan_job = client.start_file_scan(\n",
+    "    model_id=model_id, project_id=project.project_id, agent_id=AGENT_ID\n",
+    ")\n",
+    "file_scan_job.get_status(verbose=True, wait_until_finish=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d587978b",
+   "metadata": {},
+   "source": [
+    "## **Get File Scan Result for Registered Model**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1313474f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "file_scan_result = client.get_file_scan_result(file_scan_id=file_scan_job.job_id)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d3658ba7-783e-4062-a377-adbc906110b5",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "## **Start Stress Test**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "84ec5f73-b803-4a55-8150-ea57b2096669",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "stress_test_config = {\n",
+    "    \"run_name\": \"DistilBERT Adversarial Robustness\",\n",
+    "    \"data_info\": {\n",
+    "        \"ref_dataset_id\": ref_dataset_id,\n",
+    "        \"eval_dataset_id\": eval_dataset_id,\n",
+    "    },\n",
+    "    \"model_id\": model_id,\n",
+    "    \"categories\": [\"TEST_CATEGORY_TYPE_ADVERSARIAL\"],\n",
+    "    \"test_suite_config\": {\n",
+    "        \"global_exclude_columns\": [\"idx\"]\n",
+    "    },\n",
+    "}\n",
+    "stress_job = client.start_stress_test(\n",
+    "    stress_test_config, project.project_id, agent_id=AGENT_ID\n",
+    ")\n",
+    "stress_job.get_status(verbose=True, wait_until_finish=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0bf6f351-719c-4f35-bddd-60bcb4eee8fd",
+   "metadata": {},
+   "source": [
+    "## **Review Adversarial Stress Test Run**\n",
+    "\n",
+    "Now that the test run is complete, we can check out the results in the RIME web interface."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9f9acd72-b9c6-48c5-a30f-2fdc9cba89b7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "test_run = stress_job.get_test_run()\n",
+    "test_run"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8ddb22ae-f29d-4520-ae41-c30d04682210",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "## **Query Results**\n",
+    "\n",
+    "Alternatively, we can query the test case results to identify model vulnerabilities."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a6684384-d58c-45ac-b4f8-46ee03453356",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "result_df = test_run.get_result_df()\n",
+    "result_df.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e19b26bb-8b21-466a-8ee4-cab74e2fd2c6",
+   "metadata": {},
+   "source": [
+    "**Test Severity**: Let's plot some of the results. First, let's check the severity distribution of attack tests."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3278b31f-40f7-44ba-8ebb-4bbd6fc3368a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import seaborn as sns\n",
+    "import matplotlib.pyplot as plt\n",
+    "sns.set_theme(style=\"white\")\n",
+    "\n",
+    "severity_cols = [col for col in result_df.columns if 'severity_counts' in col.lower()]\n",
+    "severity_counts = result_df[severity_cols].iloc[0]\n",
+    "plt.pie(severity_counts, labels=severity_cols)\n",
+    "plt.show() "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4f2b3246-3af2-49dc-97f5-cd5ca681bdac",
+   "metadata": {},
+   "source": [
+    "## **Reviewing Test Case Results**\n",
+    "\n",
+    "Next, let's look at the results by attack type."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "40e8bb78-9125-418f-a344-8f7d2ac50ae9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "test_cases_df = test_run.get_test_cases_df(show_test_case_metrics=True)\n",
+    "test_cases_df.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "70ab4ad4-c4d1-4154-9fe4-87941aff633f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig = plt.figure(figsize=(10,10))\n",
+    "test_type_pass_rates = {name: (batch_df['severity'] == 'SEVERITY_PASS').sum() / len(batch_df) for name, batch_df in test_cases_df.groupby(\"test_batch_type\")}\n",
+    "sns.barplot(y=list(test_type_pass_rates.keys()), x=list(test_type_pass_rates.values()), orient='h')\n",
+    "plt.xlabel('Pass Rate')\n",
+    "plt.ylabel('Test Type')\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4cb69128",
+   "metadata": {},
+   "source": [
+    "You can also query certain test batch-level metrics, including the model's accuracy on the original and perturbed inputs, and the average number of queries for the attack algorithm."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "889e196e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "\n",
+    "col_name_map = {\n",
+    "    \"test_name\": \"Test Name\",\n",
+    "    \"PERFORMANCE_METRIC_VALUE:original_accuracy\": \"Original Accuracy\",\n",
+    "    \"PERFORMANCE_METRIC_VALUE:perturbed_accuracy\": \"Perturbed Accuracy\",\n",
+    "    \"ATTACK_DETAILS:avg_queries\": \"Average Number of Queries\",\n",
+    "}\n",
+    "\n",
+    "def _all_col_names_in_summary_df(col_names, summary_df):\n",
+    "    for col_name in col_names:\n",
+    "        if col_name not in summary_df.index:\n",
+    "            return False\n",
+    "    return True\n",
+    "\n",
+    "test_batches = test_run.get_test_batches()\n",
+    "all_summaries = []\n",
+    "for batch in test_batches:\n",
+    "    summary_df = batch.summary(show_batch_metrics=True)\n",
+    "    test_name = summary_df['test_name']\n",
+    "    if _all_col_names_in_summary_df(col_name_map.keys(), summary_df):\n",
+    "        all_summaries.append(summary_df[list(col_name_map.keys())])\n",
+    "metrics_df = pd.concat(all_summaries, axis=1).T\n",
+    "metrics_df = metrics_df.rename(columns=col_name_map).set_index(\"Test Name\")\n",
+    "metrics_df.sort_values(by=\"Perturbed Accuracy\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5fe66347-cf70-40e3-9fe4-f82e463f5696",
+   "metadata": {},
+   "source": [
+    "It's evident that while this model is fairly robust to simple transformation-style augmentations, it fails to withstand some character-level evolutionary attacks, indicating that additional data augmentation and/or a data sanitation pipeline should be applied before this model goes into production! One way to add additional augmented data to your training problem is through querying the results:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2a1a67ba-8fed-4046-b923-2ab3fe99916a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "\n",
+    "def filter_rows(text_series: pd.Series, label_series: pd.Series) -> pd.DataFrame:\n",
+    "    filter_indices = ~text_series.isna()\n",
+    "    return pd.DataFrame({'Augmented': text_series[filter_indices], \"Labels\": label_series[filter_indices]})\n",
+    "\n",
+    "failed_df = test_cases_df[test_cases_df['severity'] == 'SEVERITY_ALERT']\n",
+    "\n",
+    "# attacks examples\n",
+    "perturbed_text_col =  [col for col in test_cases_df.columns if col.endswith('perturbed_sentence')][0] \n",
+    "class_col = [col for col in test_cases_df.columns if col.endswith('original_class')][0]\n",
+    "perturbed_df = filter_rows(failed_df[perturbed_text_col], failed_df[class_col])\n",
+    "\n",
+    "perturbed_df.head()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.15"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "ca72df3b9ba417119a386bc7f6836e81c78349bc450cdbaf3afafb90bdf8ed1f"
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/demo_notebooks/RIME_Bias_and_Fairness_Walkthrough_Income.ipynb
+++ b/notebooks/demo_notebooks/RIME_Bias_and_Fairness_Walkthrough_Income.ipynb
@@ -1,0 +1,537 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "K05kWwxAT9uN"
+   },
+   "source": [
+    "# **RI Bias and Fairness Income Classification Walkthrough**\n",
+    "\n",
+    "> ▶️ **Try this in Colab!** Run the [RI Bias and Fairness Income Classification Walkthrough in Google Colab](https://colab.research.google.com/github/RobustIntelligence/docs/blob/main/notebooks/demo_notebooks/RIME_Bias_and_Fairness_Walkthrough_Income.ipynb). \n",
+    "\n",
+    "You are a data scientist at the Census Bureau. The data science team has been tasked with implementing a classification model to predict whether an individual's income is above $50k USD. The primary goal of this project is to test the hypothesis that income inequality is _not_ dependent on protected attributes. One could imagine such models being used downstream for various purposes, such as loan approval or funding allocation. A biased model could yield disadvantageous outcomes for protected groups. For instance, we may find that an individual with a specific race or race/gender combination causes the model to consistently predict a low income, causing a higher rate of loan rejection. \n",
+    "    \n",
+    "\n",
+    "In this Notebook Walkthrough, we will walkthrough our core product of **AI Stress Testing** in a fairness setting. RIME AI Stress Testing allows you to test the developed model and datasets. With this bias and fairness setting, you will be able to verify your AI model for compliance-related issues. \n",
+    "\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "APMTB6F7byjr"
+   },
+   "source": [
+    "## **Install Dependencies, Import Libraries and Download Data**\n",
+    "Run the cell below to install libraries to receive data, install our SDK, and load analysis libraries."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "-Qr8pHVOcNz7"
+   },
+   "outputs": [],
+   "source": [
+    "!pip install rime-sdk &> /dev/null\n",
+    "\n",
+    "import pandas as pd\n",
+    "from pathlib import Path\n",
+    "from rime_sdk import Client"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install https://github.com/RobustIntelligence/ri-public-examples/archive/master.zip\n",
+    "from ri_public_examples.download_files import download_files\n",
+    "download_files('tabular-2.0/income', 'income')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "90zo7hdkmKyW"
+   },
+   "source": [
+    "## **Establish the RIME Client**\n",
+    "\n",
+    "To get started, provide the API credentials and the base domain/address of the RIME service. You can generate and copy an API token from the API Access Tokens Page under Workspace settings. For the domian/address of the RIME service, contact your admin. \n",
+    "\n",
+    "![img_1](https://drive.google.com/uc?id=1vMDhZii8yq22iuqSM8-Vqt3sZ2F3tPyz)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "Ns6m8I-qsCzF",
+    "outputId": "9c49965d-4f1f-4cc2-cdbe-2099fee38b6a"
+   },
+   "outputs": [],
+   "source": [
+    "API_TOKEN = '' # PASTE API_KEY \n",
+    "CLUSTER_URL = '' # PASTE DEDICATED DOMAIN OF RIME SERVICE (eg: rime.stable.rbst.io)\n",
+    "AGENT_ID = '' # PASTE AGENT_ID IF USING AN AGENT THAT IS NOT THE DEFAULT\n",
+    "client = Client(CLUSTER_URL, API_TOKEN)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "pIjQx9KUvWCF"
+   },
+   "source": [
+    "## **Create a New Project**\n",
+    "\n",
+    "You can create projects in RIME to organize your test runs. Each project represents a workspace for a given machine learning task. It can contain multiple candidate models, but should only contain one promoted production model.  "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "YEghhVY8vy6K"
+   },
+   "outputs": [],
+   "source": [
+    "description = (\n",
+    "    \"Use the Robust Intelligence platform to help ensure that your\"\n",
+    "    \" models are compliant and to facilitate easy communication\"\n",
+    "    \" between your data science and risk teams. Demonstration\"\n",
+    "    \" uses the Adult Census Income dataset\"\n",
+    "    \" (https://www.kaggle.com/datasets/uciml/adult-census-income)\"\n",
+    "    \" and a model trained to predict whether someones annual\" \n",
+    "    \" income exceeds $50,000.\"\n",
+    ")\n",
+    "project = client.create_project(\n",
+    "    name=\"Tabular Bias and Fairness Income Demo\", \n",
+    "    description=description, \n",
+    "    model_task=\"MODEL_TASK_BINARY_CLASSIFICATION\"\n",
+    ")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "4CQU6vkeDwbz",
+    "outputId": "5bd53fb3-85a4-49a5-af4b-1374bf73a27d"
+   },
+   "outputs": [],
+   "source": [
+    "project.project_id"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "eXZ6e7kiTit6"
+   },
+   "source": [
+    "**Go back to the UI to see the new `Tabular Bias and Fairness Income Demo` project.**"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "3lsxeLehwN7Y"
+   },
+   "source": [
+    "## **Training an Income Model and Uploading the Model + Datasets**\n",
+    "\n",
+    "Let's first take a lot at what the dataset looks like. We can observe that the data consists of a mix of categorical and numeric features."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "rS6ST9KhZPEp",
+    "outputId": "256f000d-1416-4080-cf36-ae78367dd8d8"
+   },
+   "outputs": [],
+   "source": [
+    "pd.read_csv('income/data/ref.csv').head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "6Mbokt95ZPfe"
+   },
+   "source": [
+    "For this demo, we are going to use a pretrained CatBoostClassifier Model. \n",
+    "\n",
+    "The model predicts whether a particular individual has an income of >50k.\n",
+    "\n",
+    "We now want to kick off RIME Stress Tests, in a compliance setting, that will help us determine if the model is biased against protected attributes. In order to do this, we will upload this pre-trained model, the reference dataset the model was trained on, and the evaluation dataset the model was evaluated on to an S3 bucket that can be accessed by RIME."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "upload_path = \"ri_public_examples_income\"\n",
+    "\n",
+    "model_s3_dir = client.upload_directory(\n",
+    "    Path('income/models'), upload_path=upload_path\n",
+    ")\n",
+    "model_s3_path = model_s3_dir + \"/model.py\"\n",
+    "\n",
+    "ref_s3_path = client.upload_file(\n",
+    "    Path('income/data/ref.csv'), upload_path=upload_path\n",
+    ")\n",
+    "eval_s3_path = client.upload_file(\n",
+    "    Path('income/data/eval.csv'), upload_path=upload_path\n",
+    ")\n",
+    "\n",
+    "ref_preds_s3_path = client.upload_file(\n",
+    "    Path(\"income/data/ref_preds.csv\"), upload_path=upload_path\n",
+    ")\n",
+    "eval_preds_s3_path = client.upload_file(\n",
+    "    Path(\"income/data/eval_preds.csv\"), upload_path=upload_path\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Once the data and model are uploaded to S3, we can register them to RIME. In this bias and fairness setting, we require some additional information when registering datasets. Within the `data_params` parameter in the registering function, we include the protected features present in the data such that we can run our bias and fairness tests on those features. Once the datasets and models are registered, we can refer to these resources using their RIME-generated ID's."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "U1mcyn9JwdWQ",
+    "outputId": "8af56c7d-58f5-4a70-c05a-e9b7d27b92e5"
+   },
+   "outputs": [],
+   "source": [
+    "from datetime import datetime\n",
+    "\n",
+    "dt = str(datetime.now())\n",
+    "\n",
+    "# Note: models and datasets need to have unique names.\n",
+    "model_id = project.register_model_from_path(f\"model_{dt}\", model_s3_path, agent_id=AGENT_ID)\n",
+    "\n",
+    "ref_dataset_id = project.register_dataset_from_file(\n",
+    "    f\"ref_dataset_{dt}\",\n",
+    "    ref_s3_path,\n",
+    "    data_params={\"label_col\": \"income\", \"protected_features\": [\"sex\", \"race\", \"education\", \"age\", \"native.country\"]},\n",
+    "    agent_id=AGENT_ID\n",
+    ")\n",
+    "eval_dataset_id = project.register_dataset_from_file(\n",
+    "    f\"eval_dataset_{dt}\",\n",
+    "    eval_s3_path,\n",
+    "    data_params={\"label_col\": \"income\", \"protected_features\": [\"sex\", \"race\", \"education\", \"age\", \"native.country\"]},\n",
+    "    agent_id=AGENT_ID\n",
+    ")\n",
+    "\n",
+    "project.register_predictions_from_file(\n",
+    "    ref_dataset_id, model_id, ref_preds_s3_path, agent_id=AGENT_ID\n",
+    ")\n",
+    "project.register_predictions_from_file(\n",
+    "    eval_dataset_id, model_id, eval_preds_s3_path, agent_id=AGENT_ID\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "yCasNMsy0Avt"
+   },
+   "source": [
+    "## **Running a Stress Test with Bias and Fairness**\n",
+    "\n",
+    "AI Stress Tests allow you to test your data and model before deployment. They are a comprehensive suite of hundreds of tests that automatically identify implicit assumptions and weaknesses of pre-production models. Each stress test is run on a single model and its associated reference and evaluation datasets. \n",
+    "\n",
+    "To run Stress Tests with the Bias & Fairness mode, there are two main changes to make. The first has been done already, namely specifying a set of `protected_features` in the `data_param` parameters of both datasets. The protected features are the specific features that you want Stress Tests to run over in order to test your model for signs of bias. Additionally, you will want to specify the Bias and Fairness Category in stress test config. This category does not run by default so specifying as such is necessary:\n",
+    "\n",
+    "```python\n",
+    "stress_test_config = {\n",
+    "        # rest of configuration ...\n",
+    "        \"categories\": [\"TEST_CATEGORY_TYPE_BIAS_AND_FAIRNESS\"]\n",
+    "}\n",
+    "```\n",
+    "\n",
+    "Note how the \"categories\" field contains \"Bias and Fairness\".\n",
+    "\n",
+    "\n",
+    "Below is a sample configuration of how to setup and run a RIME Stress Test."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "MA-mVn3pzVA1",
+    "outputId": "68d86dec-6f0c-452a-8927-0c9c38071dd8"
+   },
+   "outputs": [],
+   "source": [
+    "stress_test_config = {\n",
+    "    \"run_name\": \"Bias and Fairness Demo Run\",\n",
+    "    \"data_info\": {\n",
+    "        \"ref_dataset_id\": ref_dataset_id,\n",
+    "        \"eval_dataset_id\": eval_dataset_id,\n",
+    "    },\n",
+    "    \"model_id\": model_id,\n",
+    "    \"categories\": [\"TEST_CATEGORY_TYPE_BIAS_AND_FAIRNESS\", \"TEST_CATEGORY_TYPE_MODEL_PERFORMANCE\", \"TEST_CATEGORY_TYPE_SUBSET_PERFORMANCE\"],\n",
+    "}\n",
+    "stress_job = client.start_stress_test(test_run_config=stress_test_config, project_id=project.project_id, agent_id=AGENT_ID)\n",
+    "stress_job.get_status(verbose=True, wait_until_finish=True)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "LFB5nVEaTtnB"
+   },
+   "source": [
+    "**Wait for a couple minutes and your results will appear in the UI.**"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "ovrKDoifIxIm"
+   },
+   "source": [
+    "## **Compliance Stress Test Results**\n",
+    "\n",
+    "In the compliance setting, the stress tests are organized around a central \"Compliance\" tab.\n",
+    "You can view the detailed results in the UI by running the below cell and redirecting to the generated link. This page shows granular results for a given AI Stress Test run. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "h2iYOcGiI16-",
+    "outputId": "5dca4289-5279-460c-fa9a-70c71ff336bc"
+   },
+   "outputs": [],
+   "source": [
+    "test_run = stress_job.get_test_run()\n",
+    "test_run"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "1zKDo7TOYYds"
+   },
+   "source": [
+    "### **Analyzing the Results**\n",
+    "\n",
+    "Below you can see a snapshot of the results. \n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "c4m-fHnfDwb2"
+   },
+   "source": [
+    "![img_2](https://drive.google.com/uc?id=1LAVakrDfy1NDDzJx43LLX2lGB8Yzqnrd)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "8CAVd47ZDwb2"
+   },
+   "source": [
+    "Similar to running RIME Stress Tests in the default setting, we surface an overall distribution of test severities, model metrics, as well as key insights to the right. Here the insights are primarily focused on problematic features and subsets within the set of specified protected features.\n",
+    "\n",
+    "We can take a look at a few tests, starting with the Demographic Parity test."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "S0sZ4Jl2Dwb2"
+   },
+   "source": [
+    "![img_3](https://drive.google.com/uc?id=1WO7p9jBXw53UB1GCUmEgEL0hNYYn8jh_)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "SWxWxg55Dwb2"
+   },
+   "source": [
+    "This test measures the ratio in minimum/maximum positive prediction rate between the subsets of a feature. When we look at the results of the Demographic Parity test over the \"race\" feature, we see that the positive prediction rate is far below the 80% threshold for various races. This means that for individuals in these groups, the model consistently predicts that they will have a low income. One could imagine that for downstream tasks such as loan approval that have a direct effect on the individual, such a model will lead to negative outcomes for protected subgroups.\n",
+    "\n",
+    "Next we can take a look at the Discrimination By Proxy test."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "2LLn77EEDwb3"
+   },
+   "source": [
+    "![img_4](https://drive.google.com/uc?id=1Ej49iHkJmWkEh5M4HjFtE4O8P0PWwQjW)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "ti-KSCZpDwb3"
+   },
+   "source": [
+    "In most if not all cases, the protected features are not directly used by the model. However, there may exist \"proxy\" features used by the model that have a high mutual information with the protected features; if the model depends heavily on these features, then the model will still exhibit biased predictions against protected subgroups. The \"Discrimination By Proxy\" test measures the mutual information between a protected feature and proxy features. Here we see that `sex` as a protected feature has a high mutual information with `relationship`, a proxy feature. \n",
+    "\n",
+    "Next we can take a look at the Feature Independence Test."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "CrlodrXCDwb3"
+   },
+   "source": [
+    "![img_5](https://drive.google.com/uc?id=1K6vOXxjbWSWSk_xHrs_IjRKugdC3D18u)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "C1ElXkf9Dwb3"
+   },
+   "source": [
+    "This test is model-agnostic - it measures if there is a relationship between the protected (categorical) attribute and the label by running a Chi-Squared Test. Here we see that there does exist a statistical relationship between race, sex, and education and the label. This implies that even before the model is trained, we will want to carefully understand if the data and task itself is inherently \"biased\", and decide if we want to adjust how we train the model to correct for these biases.\n",
+    "\n",
+    "Next, we run the Intersectional Group Fairness Test."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "cNmXsaNrDwb3"
+   },
+   "source": [
+    "![img_6](https://drive.google.com/uc?id=1o8R0mbmV0NMNCMRD_DEQ2MCU5Du4B6UH)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "VvPFALHBDwb3"
+   },
+   "source": [
+    "This test runs over every pair of protected categorical attributes and analyzes the difference in positive prediction rate between every subset pair. Here we see that when the test is run over `sex`, `education`, the difference in positive prediction rate between `Male`, `Masters` and `Female`, `HS-grad`, is very high, indicating bias over protected attributes. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "XGivw_Weookf"
+   },
+   "source": [
+    "### **Programmatically Querying the Results**"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "HB4A2GouWysL"
+   },
+   "source": [
+    "RIME not only provides you with an intuitive UI to visualize and explore these results, but also allows you to programmatically query these results. This allows customers to integrate with their MLOps pipeline, log results to experiment management tools like MLFlow, bring automated decision making to their ML practicies, or store these results for future references. \n",
+    "\n",
+    "Run the below cell to programmatically query the results. The results are outputed as a pandas dataframe."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "fTWLakM8VQj6"
+   },
+   "source": [
+    "**Access results at the a test run overview level**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "dgawCIZWLFST"
+   },
+   "outputs": [],
+   "source": [
+    "test_run_result = test_run.get_result_df()\n",
+    "test_run_result.to_csv(\"Income_Test_Run_Results.csv\")\n",
+    "test_run_result"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "tUUcNh7XVUPl"
+   },
+   "source": [
+    "**Access detailed test results at each individual test cases level.**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "u2qh2linVIt9"
+   },
+   "outputs": [],
+   "source": [
+    "test_case_result = test_run.get_test_cases_df()\n",
+    "test_case_result.to_csv(\"Income_Test_Case_Results.csv\")\n",
+    "test_case_result.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "colab": {
+   "collapsed_sections": [],
+   "name": "RIME_Compliance_Walkthrough.ipynb",
+   "provenance": []
+  },
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/notebooks/demo_notebooks/RIME_Bias_and_Fairness_Walkthrough_Lending.ipynb
+++ b/notebooks/demo_notebooks/RIME_Bias_and_Fairness_Walkthrough_Lending.ipynb
@@ -1,0 +1,803 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "K05kWwxAT9uN",
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "# **RI Bias and Fairness Lending Classification Walkthrough**\n",
+    "\n",
+    "> ▶️ **Try this in Colab!** Run the [RI Bias and Fairness Lending Classification Walkthrough in Google Colab](https://colab.research.google.com/github/RobustIntelligence/docs/blob/main/notebooks/demo_notebooks/RIME_Bias_and_Fairness_Walkthrough_Lending.ipynb). \n",
+    "\n",
+    "You are a data scientist at a Bank. The data science team has been tasked with implementing a binary classification model to predict whether an individual will default on a loan. The primary goal of this project is to test if the model is compliant with financial regulations. Part of this will be testing whether the model is biased against certain protected features. One could imagine such models being used downstream for various purposes, such as loan approval or funding allocation. A biased model could yield disadvantageous outcomes for protected groups. For instance, we may find that an individual with a specific race or race/gender combination causes the model to consistently predict a higher probability of them defaulting, causing a higher rate of loan rejection.\n",
+    "    \n",
+    "\n",
+    "In this Notebook Walkthrough, we will walkthrough our core products of **AI Stress Testing** and **AI Firewall** in a *Bias and Fairness* setting. RIME AI Stress Testing allows you to test the developed model and datasets. With this compliance-focused setting, you will be able to verify your AI model for bias and fairness issues. RIME AI Firewall allows you to continue monitoring your deployed model for bias."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "APMTB6F7byjr",
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "## **Install Dependencies, Import Libraries and Download Data**\n",
+    "Run the cell below to install libraries to recieve data, install our SDK, and load analysis libraries."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "-Qr8pHVOcNz7",
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "!pip install rime-sdk &> /dev/null"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "f03qjornDwbr",
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "from pathlib import Path\n",
+    "from rime_sdk import Client"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "UnbHm8sJYHUD",
+    "outputId": "b8ec9a17-2b4c-482b-ff1d-363c1530b384",
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "!pip install https://github.com/RobustIntelligence/ri-public-examples/archive/master.zip \n",
+    "from ri_public_examples.download_files import download_files\n",
+    "download_files('tabular-2.0/lending', 'lending')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "90zo7hdkmKyW",
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "## **Establish the RIME Client**\n",
+    "\n",
+    "To get started, provide the API credentials and the base domain/address of the RIME service. You can generate and copy an API token from the API Access Tokens Page under Workspace settings. For the domian/address of the RIME service, contact your admin. \n",
+    "\n",
+    "![img_1](https://drive.google.com/uc?id=1vMDhZii8yq22iuqSM8-Vqt3sZ2F3tPyz)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "Ns6m8I-qsCzF",
+    "outputId": "266cee4c-bcab-4d19-a6bc-eb6789e62202",
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "API_TOKEN = '' # PASTE API_KEY \n",
+    "CLUSTER_URL = '' # PASTE DEDICATED DOMAIN OF RIME SERVICE (eg: rime.stable.rbst.io)\n",
+    "AGENT_ID = '' # PASTE AGENT_ID IF USING AN AGENT THAT IS NOT THE DEFAULT"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "client = Client(CLUSTER_URL, API_TOKEN)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "pIjQx9KUvWCF",
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "## **Create a New Project**\n",
+    "\n",
+    "You can create projects in RIME to organize your test runs. Each project represents a workspace for a given machine learning task. It can contain multiple candidate models, but should only contain one promoted production model.  "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "YEghhVY8vy6K",
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "description = (\n",
+    "    \"Continuously test the fairness and bias of tabular models in production\"\n",
+    "    \" using Continuous Tests.\"\n",
+    "    \" Demonstration uses the Lending Club dataset, which is used\"\n",
+    "    \" to predict whether someone will repay a loan.\"\n",
+    ")\n",
+    "project = client.create_project(\n",
+    "    name=\"Bias and Fairness Continuous Testing Demo\", \n",
+    "    description=description,\n",
+    "    model_task=\"MODEL_TASK_BINARY_CLASSIFICATION\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 35
+    },
+    "id": "4CQU6vkeDwbz",
+    "outputId": "425104d7-8340-4957-ab40-0d581af953e7",
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "project.project_id"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "eXZ6e7kiTit6",
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "**Go back to the UI to see the new `Bias and Fairness Demo` project.**"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "3lsxeLehwN7Y",
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "## **Training a Lending Model and Uploading the Model + Datasets**\n",
+    "\n",
+    "Let's first take a lot at what the dataset looks like. We can observe that the data consists of a mix of categorical and numeric features."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pd.read_csv('lending/data/ref.csv').head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "6Mbokt95ZPfe",
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "For this demo, we are going to use a pretrained CatBoostClassifier Model. \n",
+    "\n",
+    "The model predicts whether an individual will default on their loan.\n",
+    "\n",
+    "We now want to kick off RIME Stress Tests, in a compliance setting, that will help us determine if the model is biased against protected attributes. In order to do this, we will upload this pre-trained model, the reference dataset the model was trained on, and the evaluation dataset the model was evaluated on to an S3 bucket that can be accessed by RIME."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "U1mcyn9JwdWQ",
+    "outputId": "59b08804-3542-43f5-f5ba-a89078951e78",
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "upload_path = \"ri_public_examples_lending\"\n",
+    "\n",
+    "model_s3_dir = client.upload_directory(\n",
+    "    Path('lending/models'), upload_path=upload_path\n",
+    ")\n",
+    "model_s3_path = model_s3_dir + \"/model.py\"\n",
+    "\n",
+    "ref_s3_path = client.upload_file(\n",
+    "    Path('lending/data/ref.csv'), upload_path=upload_path\n",
+    ")\n",
+    "eval_s3_path = client.upload_file(\n",
+    "    Path('lending/data/eval.csv'), upload_path=upload_path\n",
+    ")\n",
+    "\n",
+    "ref_preds_s3_path = client.upload_file(\n",
+    "    Path(\"lending/data/ref_preds.csv\"), upload_path=upload_path\n",
+    ")\n",
+    "eval_preds_s3_path = client.upload_file(\n",
+    "    Path(\"lending/data/eval_preds.csv\"), upload_path=upload_path\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Once the data and model are uploaded to S3, we can register them to RIME. In this bias and fairness setting, we require some additional information when registering datasets. Within the `data_params` parameter in the registering function, we include the protected features present in the data such that we can run our bias and fairness tests on those features. Once the datasets and models are registered, we can refer to these resources using their RIME-generated ID's."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from datetime import datetime\n",
+    "\n",
+    "dt = str(datetime.now())\n",
+    "\n",
+    "# Note: models and datasets need to have unique names.\n",
+    "model_id = project.register_model_from_path(f\"model_{dt}\", model_s3_path, agent_id=AGENT_ID)\n",
+    "\n",
+    "ref_dataset_id = project.register_dataset_from_file(f\"ref_dataset_{dt}\",\n",
+    "                                                    ref_s3_path,\n",
+    "                                                    data_params={\"label_col\": \"loan_status\",\n",
+    "                                                                 \"protected_features\": [\"sex\", \"race\", \"addr_state\"]\n",
+    "                                                                },\n",
+    "                                                   agent_id=AGENT_ID)\n",
+    "eval_dataset_id = project.register_dataset_from_file(f\"eval_dataset_{dt}\",\n",
+    "                                                     eval_s3_path,\n",
+    "                                                     data_params={\"label_col\": \"loan_status\",\n",
+    "                                                                  \"protected_features\": [\"sex\", \"race\", \"addr_state\"]\n",
+    "                                                                 },\n",
+    "                                                    agent_id=AGENT_ID)\n",
+    "ref_pred_id = project.register_predictions_from_file(ref_dataset_id, model_id, ref_preds_s3_path, agent_id=AGENT_ID)\n",
+    "\n",
+    "eval_pred_id = project.register_predictions_from_file(eval_dataset_id, model_id, eval_preds_s3_path, agent_id=AGENT_ID)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "yCasNMsy0Avt",
+    "pycharm": {
+     "name": "#%% md\n"
+    },
+    "tags": []
+   },
+   "source": [
+    "## **Running a Stress Test with Bias and Fairness**\n",
+    "\n",
+    "AI Stress Tests allow you to test your data and model before deployment. They are a comprehensive suite of hundreds of tests that automatically identify implicit assumptions and weaknesses of pre-production models. Each stress test is run on a single model and its associated reference and evaluation datasets. \n",
+    "\n",
+    "To run Stress Tests with the Bias & Fairness mode, there are two main changes to make. The first has been done already, namely specifying a set of `protected_features` in the `data_param` parameters of both datasets. The protected features are the specific features that you want Stress Tests to run over in order to test your model for signs of bias. Additionally, you will want to specify the Bias and Fairness Category in stress test config. This category does not run by default so specifying as such is necessary:\n",
+    "\n",
+    "```python\n",
+    "stress_test_config = {\n",
+    "        # rest of configuration ...\n",
+    "        \"categories\": [\"TEST_CATEGORY_TYPE_BIAS_AND_FAIRNESS\"]\n",
+    "}\n",
+    "```\n",
+    "\n",
+    "Note how the \"categories\" field contains \"Bias and Fairness\".\n",
+    "\n",
+    "\n",
+    "Below is a sample configuration of how to setup and run a RIME Stress Test."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "MA-mVn3pzVA1",
+    "outputId": "c75f28b8-93a7-44e8-d451-1fcec26f7ff6",
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "stress_test_config = {\n",
+    "    \"data_info\": {\n",
+    "        \"ref_dataset_id\": ref_dataset_id,\n",
+    "        \"eval_dataset_id\": eval_dataset_id\n",
+    "    },\n",
+    "    \"model_id\": model_id,\n",
+    "    \"run_name\": \"Loan Default Prediction - Lending Club\",\n",
+    "    \"categories\": [\"TEST_CATEGORY_TYPE_BIAS_AND_FAIRNESS\"]\n",
+    "}\n",
+    "stress_job = client.start_stress_test(test_run_config=stress_test_config, project_id=project.project_id, agent_id=AGENT_ID)\n",
+    "stress_job.get_status(verbose=True, wait_until_finish=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "LFB5nVEaTtnB",
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "**Wait for a couple minutes and your results will appear in the UI.**"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "ovrKDoifIxIm",
+    "pycharm": {
+     "name": "#%% md\n"
+    },
+    "tags": []
+   },
+   "source": [
+    "## **Bias and Fairness Stress Test Results**\n",
+    "\n",
+    "The stress tests are organized around a central \"Bias and Fairness\" tab.\n",
+    "You can view the detailed results in the UI by running the above cell and redirecting to the generated link. This page shows granular results for a given AI Stress Test run. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "h2jQYUDmknsU",
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "![img_3](https://drive.google.com/uc?id=1-pg7NhGUDDGzLx7DGogOrj1xWqOhw6s5)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "Similar to running RIME Stress Tests in the default setting, we surface an overall distribution of test severities, model metrics, as well as key insights to the right. This test suite comprises a selection of Bias and Fairness tests over any protected features, Attack tests over all features,\n",
+    "and Abnormal Inputs tests over all features. These tests align with financial regulatory standards. Lets take a closer look at the Demographic Parity test:"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "h2jQYUDmknsU",
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "![img_4](https://drive.google.com/uc?id=1sBlvaUHu_Gwut_hmFN0tR_WJmcbpfTLZ)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "This test is commonly known as the demographic parity or statistical parity test in fairness literature. This test checks whether the model performs equally well across a given subset of rows as it does across the whole dataset. The key detail displays the performance difference between the lowest performing subset and the overall population. The test first splits the dataset into various subsets depending on the quantiles of a given feature column. If the feature is categorical, the data is split based on the feature values. We then test whether the Positive Prediction Rate of model predictions within a specific subset is significantly different than the model prediction Positive Prediction Rate over the entire 'population'.\n",
+    "\n",
+    "We can see that the model fails the demographic parity test for two of the three protected features that we configured."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 279
+    },
+    "id": "h2iYOcGiI16-",
+    "outputId": "2f6c190f-9081-4b65-f29b-8743879b1de6",
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "test_run = stress_job.get_test_run()\n",
+    "test_run"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "test_case_result = test_run.get_result_df()\n",
+    "test_case_result.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "XGivw_Weookf",
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "### **Programmatically Querying the Results**"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "HB4A2GouWysL",
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "RIME not only provides you with an intuitive UI to visualize and explore these results, but also allows you to programmatically query these results. This allows customers to integrate with their MLOps pipeline, log results to experiment management tools like MLFlow, bring automated decision making to their ML practicies, or store these results for future references. \n",
+    "\n",
+    "Run the below cell to programmatically query the results. The results are outputed as a pandas dataframe."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "fTWLakM8VQj6",
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "**Access results at the a test run overview level**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "dgawCIZWLFST",
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "test_run_result = test_run.get_result_df()\n",
+    "test_run_result.to_csv(\"Lending_Test_Run_Results.csv\")\n",
+    "test_run_result"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "tUUcNh7XVUPl",
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "**Access detailed test results at each individual test cases level.**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "u2qh2linVIt9",
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "test_case_result = test_run.get_test_cases_df()\n",
+    "test_case_result.to_csv(\"Lending_Test_Case_Results.csv\")\n",
+    "test_case_result.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "ovrKDoifIxIm",
+    "pycharm": {
+     "name": "#%% md\n"
+    },
+    "tags": []
+   },
+   "source": [
+    "## **Deploy to Production and Create the AI Firewall**\n",
+    "\n",
+    "Once you have identified the best stress test run, you can deploy the associated model wrapped with the AI Firewall. The AI Firewall operates on both a datapoint and batch level. It automatically protects your model in real-time from “bad” incoming data and also alerts on statistically significant distributional drift. \n",
+    "\n",
+    "In this scenario, the data scientist is short on time and decided to deploy the existing model to production. The data scientist also creates and wraps a firewall around the model. The AI Firewall is automatically configured based on the failures identified by AI Stress testing to protect the tested model in Production."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 383
+    },
+    "id": "tt3uZvDtAbov",
+    "outputId": "277b3104-942b-4a62-fa82-21c248ef6422",
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "from datetime import timedelta\n",
+    "\n",
+    "# Create Firewall using previously registered model and dataset IDs.\n",
+    "firewall = project.create_firewall(model_id, ref_dataset_id, timedelta(days=1))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "a0Lw2YBXBkb4",
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "## **Uploading a Batch of Production Data & Model Predictions to Firewall**\n",
+    "\n",
+    "The lending model has been in production for 30 days. Production data and model predictions have been collected and stored for the past 30 days. Now, we will use Firewall to track how the model performed across the last 30 days."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "g7McYwfDUztC",
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "**Upload an Incremental Batch of Data**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 383
+    },
+    "id": "tt3uZvDtAbov",
+    "outputId": "277b3104-942b-4a62-fa82-21c248ef6422",
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "prod_s3_path = client.upload_file(\n",
+    "    Path('lending/data/incremental.csv'), \n",
+    "    upload_path=upload_path\n",
+    ")\n",
+    "prod_dataset_id = project.register_dataset_from_file(\n",
+    "    f\"prod_dataset_{dt}\", \n",
+    "    prod_s3_path, \n",
+    "    data_params={\"label_col\": \"loan_status\", \n",
+    "                 \"protected_features\": [\"sex\", \"race\", \"addr_state\"],\n",
+    "                 \"timestamp_col\": \"timestamp\"},\n",
+    ")\n",
+    "prod_preds_s3_path = client.upload_file(\n",
+    "    Path('lending/data/incremental_preds.csv'), \n",
+    "    upload_path=upload_path\n",
+    ")\n",
+    "project.register_predictions_from_file(\n",
+    "    prod_dataset_id, model_id, prod_preds_s3_path\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To run the Bias and Fairness category in Continuous Testing, you will want to specify the Bias and Fairness Category as a continuous test category. This category does not run by default so specifying as such is necessary:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "project.update_continuous_test_categories([\"TEST_CATEGORY_TYPE_BIAS_AND_FAIRNESS\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "e-ooaBT-U4yr",
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "**Run Continuous Testing over Batch of Data**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 383
+    },
+    "id": "tt3uZvDtAbov",
+    "outputId": "277b3104-942b-4a62-fa82-21c248ef6422",
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "ct_job = firewall.start_continuous_test(prod_dataset_id, agent_id=AGENT_ID)\n",
+    "ct_job.get_status(verbose=True, wait_until_finish=True)\n",
+    "firewall"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "ifxKz_p6Uc63",
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "**Wait for a couple minutes and your results will appear in the UI.**"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "vmpxUnaLMn-u",
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "\n",
+    "## **Firewall CT Overview**\n",
+    "\n",
+    "The page is the mission control for your model’s production deployment health. In it, you can see the status of continuous test runs, and see their metrics changes over time.  \n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "![img_5](https://drive.google.com/uc?id=1uT3q4pakoQSPhRf9HfxS5tyL16c3dDpx)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "MzMea8BUFOT1",
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "## **Firewall CT Results**\n",
+    "\n",
+    "The AI Firewall’s Continuous Tests operate at the batch level and provide a mechanism to monitor the health of ML deployments in production. They allow the user to understand when errors begin to occur and surface the underlying drivers of such errors. \n",
+    "\n",
+    "You can explore the results in the UI by running the below cell and redirecting to the generated link.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "Qndn2zUMLhJo",
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "firewall"
+   ]
+  }
+ ],
+ "metadata": {
+  "colab": {
+   "collapsed_sections": [],
+   "name": "RIME_Finance_Compliance_Walkthrough_Lending.ipynb",
+   "provenance": []
+  },
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/notebooks/demo_notebooks/RIME_Continuous_Test_Configuring.ipynb
+++ b/notebooks/demo_notebooks/RIME_Continuous_Test_Configuring.ipynb
@@ -1,0 +1,281 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "K05kWwxAT9uN"
+   },
+   "source": [
+    "# Updating your Continuous Test\n",
+    "   \n",
+    "\n",
+    "In this Notebook walkthrough, we will show how to update a **Continuous Test** after it has been deployed to production. The Continuous Test can be updated live to account for many service changes, such as modifying the reference dataset and upgrading the model, or configuring individual tests.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> Latest Colab version of this notebook available [here](https://colab.research.google.com/github/RobustIntelligence/docs/blob/main/notebooks/demo_notebooks/RIME_Firewall_Configuring.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Install dependencies**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install rime-sdk &> /dev/null\n",
+    "!pip install https://github.com/RobustIntelligence/ri-public-examples/archive/master.zip"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "from tempfile import TemporaryDirectory\n",
+    "from typing import List\n",
+    "\n",
+    "import pandas as pd\n",
+    "from ri_public_examples.download_files import download_files\n",
+    "from rime_sdk import Client"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Download and prep data**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "download_files('tabular-2.0/fraud', 'fraud')\n",
+    "ct_data = pd.read_csv(\"fraud/data/fraud_incremental.csv\")\n",
+    "ct_data[:len(ct_data)//2].to_csv(\"fraud/data/fraud_incremental_0.csv\", index=False)\n",
+    "ct_data[len(ct_data)//2:].to_csv(\"fraud/data/fraud_incremental_1.csv\", index=False)\n",
+    "\n",
+    "ct_preds = pd.read_csv(\"fraud/data/fraud_incremental_preds.csv\")\n",
+    "ct_preds[:len(ct_preds)//2].to_csv(\"fraud/data/fraud_incremental_0_preds.csv\", index=False)\n",
+    "ct_preds[len(ct_preds)//2:].to_csv(\"fraud/data/fraud_incremental_1_preds.csv\", index=False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Instantiate RIME client and create project**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "API_TOKEN = '' # PASTE API_KEY \n",
+    "CLUSTER_URL = '' # PASTE DEDICATED DOMAIN OF RIME SERVICE (eg: rime.stable.rbst.io)\n",
+    "AGENT_ID = '' # PASTE AGENT_ID IF USING AN AGENT THAT IS NOT THE DEFAULT"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "client = Client(CLUSTER_URL, API_TOKEN)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "description = (\n",
+    "    \"Create a Continuous Test and update the configuration after it is deployed to production.\"\n",
+    "    \" Demonstration uses a tabular binary classification dataset\"\n",
+    "    \" and model that simulates credit card fraud detection.\"\n",
+    ")\n",
+    "project = client.create_ct(\n",
+    "    \"Continuous Testing Configuration Demo\", \n",
+    "    description,\n",
+    "    \"MODEL_TASK_BINARY_CLASSIFICATION\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Upload data to S3 and register dataset and prediction set**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from datetime import datetime\n",
+    "\n",
+    "dt = str(datetime.now())\n",
+    "# Note: models and datasets need to have unique names.\n",
+    "model_id = project.register_model(f\"fraud_model_{dt}\", None, agent_id=AGENT_ID)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "upload_path = \"ri_public_examples_fraud\"\n",
+    "\n",
+    "def upload_and_register_data(dataset_name, **kwargs):\n",
+    "    dt = str(datetime.now())\n",
+    "    s3_path = client.upload_file(\n",
+    "        Path(f'fraud/data/fraud_{dataset_name}.csv'), upload_path=upload_path\n",
+    "    )\n",
+    "    preds_s3_path = client.upload_file(\n",
+    "        Path(f\"fraud/data/fraud_{dataset_name}_preds.csv\"), upload_path=upload_path\n",
+    "    )\n",
+    "    dataset_id = project.register_dataset_from_file(\n",
+    "        f\"{dataset_name}_dataset_{dt}\", s3_path, data_params={\"label_col\": \"label\", **kwargs}, agent_id=AGENT_ID\n",
+    "    )\n",
+    "    project.register_predictions_from_file(\n",
+    "        dataset_id, model_id, preds_s3_path, agent_id=AGENT_ID\n",
+    "    )\n",
+    "    return dataset_id\n",
+    "\n",
+    "ref_data_id = upload_and_register_data(\"ref\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "APMTB6F7byjr"
+   },
+   "source": [
+    "**Create a Continuous Test**\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from datetime import timedelta\n",
+    "\n",
+    "ct = project.create_ct(model_id, ref_data_id, timedelta(days=1))\n",
+    "ct"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "g7McYwfDUztC"
+   },
+   "source": [
+    "**Run Continuous Testing on a batch of production data**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "EHxteK1gUklo"
+   },
+   "outputs": [],
+   "source": [
+    "ct_data_0_id = upload_and_register_data(\"incremental_0\", timestamp_col=\"timestamp\")\n",
+    "ct_job = ct.start_continuous_test(ct_data_0_id, agent_id=AGENT_ID)\n",
+    "ct_job.get_status(verbose=True, wait_until_finish=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Update the Reference Dataset**\n",
+    "\n",
+    "Suppose a week has passed, and we have updated your model by retraining on new data. We want to update our deployed Continuous Test to reflect the new reference dataset."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "new_ref_data_id = upload_and_register_data(\"eval\")\n",
+    "\n",
+    "# Update configuration based on the new stress test run\n",
+    "ct.update_ct(ref_data_id=new_ref_data_id)\n",
+    "# The new stress test run will now be highlighted to reflect the update\n",
+    "project"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Run Continuous Testing on the latest batch of production data**\n",
+    "This time using the updated reference set as the baseline against which the production data is compared."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ct_data_1_id = upload_and_register_data(\"incremental_1\", timestamp_col=\"timestamp\")\n",
+    "ct_job = ct.start_continuous_test(ct_data_1_id, override_existing_bins=True, agent_id=AGENT_ID)\n",
+    "ct_job.get_status(verbose=True, wait_until_finish=True)"
+   ]
+  }
+ ],
+ "metadata": {
+  "colab": {
+   "collapsed_sections": [],
+   "name": "RIME_Fraud_OnboardingWalkthrough.ipynb",
+   "provenance": []
+  },
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.17"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/notebooks/demo_notebooks/RIME_Firewall_Configuring.ipynb
+++ b/notebooks/demo_notebooks/RIME_Firewall_Configuring.ipynb
@@ -1,0 +1,281 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "K05kWwxAT9uN"
+   },
+   "source": [
+    "# Updating your Continuous Test\n",
+    "   \n",
+    "\n",
+    "In this Notebook walkthrough, we will show how to update an **AI Firewall** after it has been deployed to production. The Firewall can be updated live to account for many service changes, such as modifying the reference dataset and upgrading the model, or configuring individual tests.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> Latest Colab version of this notebook available [here](https://colab.research.google.com/github/RobustIntelligence/docs/blob/main/notebooks/demo_notebooks/RIME_Firewall_Configuring.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Install dependencies**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install rime-sdk &> /dev/null\n",
+    "!pip install https://github.com/RobustIntelligence/ri-public-examples/archive/master.zip"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "from tempfile import TemporaryDirectory\n",
+    "from typing import List\n",
+    "\n",
+    "import pandas as pd\n",
+    "from ri_public_examples.download_files import download_files\n",
+    "from rime_sdk import Client"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Download and prep data**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "download_files('tabular-2.0/fraud', 'fraud')\n",
+    "ct_data = pd.read_csv(\"fraud/data/fraud_incremental.csv\")\n",
+    "ct_data[:len(ct_data)//2].to_csv(\"fraud/data/fraud_incremental_0.csv\", index=False)\n",
+    "ct_data[len(ct_data)//2:].to_csv(\"fraud/data/fraud_incremental_1.csv\", index=False)\n",
+    "\n",
+    "ct_preds = pd.read_csv(\"fraud/data/fraud_incremental_preds.csv\")\n",
+    "ct_preds[:len(ct_preds)//2].to_csv(\"fraud/data/fraud_incremental_0_preds.csv\", index=False)\n",
+    "ct_preds[len(ct_preds)//2:].to_csv(\"fraud/data/fraud_incremental_1_preds.csv\", index=False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Instantiate RIME client and create project**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "API_TOKEN = '' # PASTE API_KEY \n",
+    "CLUSTER_URL = '' # PASTE DEDICATED DOMAIN OF RIME SERVICE (eg: rime.stable.rbst.io)\n",
+    "AGENT_ID = '' # PASTE AGENT_ID IF USING AN AGENT THAT IS NOT THE DEFAULT"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "client = Client(CLUSTER_URL, API_TOKEN)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "description = (\n",
+    "    \"Create an AI Firewall and update the configuration after it is deployed to production.\"\n",
+    "    \" Demonstration uses a tabular binary classification dataset\"\n",
+    "    \" and model that simulates credit card fraud detection.\"\n",
+    ")\n",
+    "project = client.create_project(\n",
+    "    \"AI Firewall Configuration Demo\", \n",
+    "    description,\n",
+    "    \"MODEL_TASK_BINARY_CLASSIFICATION\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Upload data to S3 and register dataset and prediction set**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from datetime import datetime\n",
+    "\n",
+    "dt = str(datetime.now())\n",
+    "# Note: models and datasets need to have unique names.\n",
+    "model_id = project.register_model(f\"fraud_model_{dt}\", None, agent_id=AGENT_ID)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "upload_path = \"ri_public_examples_fraud\"\n",
+    "\n",
+    "def upload_and_register_data(dataset_name, **kwargs):\n",
+    "    dt = str(datetime.now())\n",
+    "    s3_path = client.upload_file(\n",
+    "        Path(f'fraud/data/fraud_{dataset_name}.csv'), upload_path=upload_path\n",
+    "    )\n",
+    "    preds_s3_path = client.upload_file(\n",
+    "        Path(f\"fraud/data/fraud_{dataset_name}_preds.csv\"), upload_path=upload_path\n",
+    "    )\n",
+    "    dataset_id = project.register_dataset_from_file(\n",
+    "        f\"{dataset_name}_dataset_{dt}\", s3_path, data_params={\"label_col\": \"label\", **kwargs}, agent_id=AGENT_ID\n",
+    "    )\n",
+    "    project.register_predictions_from_file(\n",
+    "        dataset_id, model_id, preds_s3_path, agent_id=AGENT_ID\n",
+    "    )\n",
+    "    return dataset_id\n",
+    "\n",
+    "ref_data_id = upload_and_register_data(\"ref\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "APMTB6F7byjr"
+   },
+   "source": [
+    "**Create a Firewall**\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from datetime import timedelta\n",
+    "\n",
+    "firewall = project.create_firewall(model_id, ref_data_id, timedelta(days=1))\n",
+    "firewall"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "g7McYwfDUztC"
+   },
+   "source": [
+    "**Run Continuous Testing on a batch of production data**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "EHxteK1gUklo"
+   },
+   "outputs": [],
+   "source": [
+    "ct_data_0_id = upload_and_register_data(\"incremental_0\", timestamp_col=\"timestamp\")\n",
+    "ct_job = firewall.start_continuous_test(ct_data_0_id, agent_id=AGENT_ID)\n",
+    "ct_job.get_status(verbose=True, wait_until_finish=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Update the Reference Dataset**\n",
+    "\n",
+    "Suppose a week has passed, and we have updated your model by retraining on new data. We want to update our deployed Firewall to reflect the new reference dataset."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "new_ref_data_id = upload_and_register_data(\"eval\")\n",
+    "\n",
+    "# Update firewall's configuration based on the new stress test run\n",
+    "firewall.update_firewall(ref_data_id=new_ref_data_id)\n",
+    "# The new stress test run will now be highlighted to reflect the firewall update\n",
+    "project"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Run Continuous Testing on the latest batch of production data**\n",
+    "This time using the updated reference set as the baseline against which the production data is compared."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ct_data_1_id = upload_and_register_data(\"incremental_1\", timestamp_col=\"timestamp\")\n",
+    "ct_job = firewall.start_continuous_test(ct_data_1_id, override_existing_bins=True, agent_id=AGENT_ID)\n",
+    "ct_job.get_status(verbose=True, wait_until_finish=True)"
+   ]
+  }
+ ],
+ "metadata": {
+  "colab": {
+   "collapsed_sections": [],
+   "name": "RIME_Fraud_OnboardingWalkthrough.ipynb",
+   "provenance": []
+  },
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/notebooks/demo_notebooks/RIME_Fraud_OnboardingWalkthrough.ipynb
+++ b/notebooks/demo_notebooks/RIME_Fraud_OnboardingWalkthrough.ipynb
@@ -1,0 +1,1096 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "K05kWwxAT9uN",
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "# **RI Fraud Classification Walkthrough**\n",
+    "\n",
+    "> ▶️ **Try this in Colab!** Run the [RI Fraud Classification Walkthrough in Google Colab](https://colab.research.google.com/github/RobustIntelligence/docs/blob/main/notebooks/demo_notebooks/RIME_Fraud_OnboardingWalkthrough.ipynb). \n",
+    "\n",
+    "You are a data scientist at a Payment Processing Company. The data science team has been tasked with implementing a Fraud Detection model and monitoring how that model performs over time. The performance of this fraud detection model directly impacts the costs of the company. In order to ensure the data science team develops the best model and the performance of this model doesn't degrade over time, the VP of Data Science purchases the RIME platform. \n",
+    "    \n",
+    "\n",
+    "In this Notebook Walkthrough, we will walkthrough 2 of RIME's core products - **AI Stress Testing** and **AI Continuous Testing**.\n",
+    "\n",
+    "1. **AI Stress Testing** is used in the model development stage. Using AI Stress Testing you can test the developed model. RIME goes beyond simply optimizing for basic model performance like accuracy and automatically discovers the model's weaknesses.\n",
+    "2. **AI Continuous Testing** is used after the model is deployed in production. Using AI Continuous Testing, you can automate the monitoring, discovery and remediation of issues that occur post-deployment."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "APMTB6F7byjr",
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "## **Install Dependencies, Import Libraries and Download Data**\n",
+    "Run the cell below to install libraries to receive data, install our SDK, and load analysis libraries."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "-Qr8pHVOcNz7",
+    "pycharm": {
+     "name": "#%%\n"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "!pip install rime-sdk &> /dev/null\n",
+    "\n",
+    "import pandas as pd\n",
+    "from pathlib import Path\n",
+    "from rime_sdk import Client"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "yxskvoMfcUl_",
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "!pip install https://github.com/RobustIntelligence/ri-public-examples/archive/master.zip\n",
+    "    \n",
+    "from ri_public_examples.download_files import download_files\n",
+    "\n",
+    "download_files('tabular-2.0/fraud', 'fraud')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "90zo7hdkmKyW",
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "## **Establish the RIME Client**\n",
+    "\n",
+    "To get started, provide the API credentials and the base domain/address of the RIME service. You can generate and copy an API token from the API Access Tokens Page under Workspace settings. For the domian/address of the RIME service, contact your admin. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "90zo7hdkmKyW",
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "![img_1](https://drive.google.com/uc?id=1vMDhZii8yq22iuqSM8-Vqt3sZ2F3tPyz)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "Ns6m8I-qsCzF",
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "API_TOKEN = '' # PASTE API_KEY \n",
+    "CLUSTER_URL = '' # PASTE DEDICATED DOMAIN OF RIME SERVICE (eg: rime.stable.rbst.io)\n",
+    "AGENT_ID = '' # PASTE AGENT_ID IF USING AN AGENT THAT IS NOT THE DEFAULT"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "client = Client(CLUSTER_URL, API_TOKEN)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "pIjQx9KUvWCF",
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "## **Create a New Project**\n",
+    "\n",
+    "You can create projects in RIME to organize your test runs. Each project represents a workspace for a given machine learning task. It can contain multiple candidate models, but should only contain one promoted production model.  "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "YEghhVY8vy6K",
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "description = (\n",
+    "    \"Run Stress Testing and Continuous Testing on a tabular\"\n",
+    "    \" binary classification model and dataset. Demonstration uses a\"\n",
+    "    \" dataset that simulates credit card fraud detection.\"\n",
+    ")\n",
+    "project = client.create_project(\n",
+    "    name='Tabular Binary Classification Demo', \n",
+    "    description=description, \n",
+    "    model_task='MODEL_TASK_BINARY_CLASSIFICATION'\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "eXZ6e7kiTit6",
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "**Go back to the UI to see the new Fraud Demo Project.**"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "3lsxeLehwN7Y",
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "## **Uploading the Model + Datasets**\n",
+    "\n",
+    "Let's first take a look at what the dataset looks like:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "rS6ST9KhZPEp",
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "df = pd.read_csv(Path('fraud/data/fraud_ref.csv'))\n",
+    "df.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "6Mbokt95ZPfe",
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "For this demo, we are going to use a pretrained CatBoostClassifier Model. \n",
+    "\n",
+    "The model predicts whether a particular transaction is fraud or not fraud.\n",
+    "\n",
+    "The model makes use of the following features - \n",
+    "\n",
+    "1.   category\n",
+    "2.   card_type\n",
+    "3.   card_company\n",
+    "4.   transaction_amount\n",
+    "5.   browser_version\n",
+    "6.   city\n",
+    "7.   country\n",
+    "\n",
+    "\n",
+    "We now want to kick off RIME Stress Tests that will help us evaluate the model in further depth beyond basic performance metrics like accuracy, precision, recall. In order to do this, we will upload this pre-trained model, the reference dataset the model was trained on, and the evaluation dataset the model was evaluated on to an S3 bucket that can be accessed by RIME."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "U1mcyn9JwdWQ",
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "upload_path = \"ri_public_examples_fraud\"\n",
+    "\n",
+    "model_s3_dir = client.upload_directory(\n",
+    "    Path('fraud/models'), upload_path=upload_path\n",
+    ")\n",
+    "model_s3_path = model_s3_dir + \"/fraud_model.py\"\n",
+    "\n",
+    "ref_s3_path = client.upload_file(\n",
+    "    Path('fraud/data/fraud_ref.csv'), upload_path=upload_path\n",
+    ")\n",
+    "eval_s3_path = client.upload_file(\n",
+    "    Path('fraud/data/fraud_eval.csv'), upload_path=upload_path\n",
+    ")\n",
+    "\n",
+    "ref_preds_s3_path = client.upload_file(\n",
+    "    Path(\"fraud/data/fraud_ref_preds.csv\"), upload_path=upload_path\n",
+    ")\n",
+    "eval_preds_s3_path = client.upload_file(\n",
+    "    Path(\"fraud/data/fraud_eval_preds.csv\"), upload_path=upload_path\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "Once the data and model are uploaded to S3, we can register them to RIME. Once they're registered, we can refer to these resources using their RIME-generated ID's."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "from datetime import datetime\n",
+    "\n",
+    "dt = str(datetime.now())\n",
+    "\n",
+    "# Note: models and datasets need to have unique names.\n",
+    "model_id = project.register_model_from_path(f\"model_{dt}\", model_s3_path, agent_id=AGENT_ID)\n",
+    "\n",
+    "ref_dataset_id = project.register_dataset_from_file(\n",
+    "    f\"ref_dataset_{dt}\", ref_s3_path, data_params={\"label_col\": \"label\"}, agent_id=AGENT_ID\n",
+    ")\n",
+    "eval_dataset_id = project.register_dataset_from_file(\n",
+    "    f\"eval_dataset_{dt}\", eval_s3_path, data_params={\"label_col\": \"label\"}, agent_id=AGENT_ID\n",
+    ")\n",
+    "\n",
+    "project.register_predictions_from_file(\n",
+    "    ref_dataset_id, model_id, ref_preds_s3_path, agent_id=AGENT_ID\n",
+    ")\n",
+    "project.register_predictions_from_file(\n",
+    "    eval_dataset_id, model_id, eval_preds_s3_path, agent_id=AGENT_ID\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "yCasNMsy0Avt",
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "## **Running a Stress Test**\n",
+    "\n",
+    "AI Stress Tests allow you to test your data and model before deployment. They are a comprehensive suite of hundreds of tests that automatically identify implicit assumptions and weaknesses of pre-production models. Each stress test is run on a single model and its associated reference and evaluation datasets. \n",
+    "\n",
+    "Below is a sample configuration of how to setup and run a RIME Stress Test."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "MA-mVn3pzVA1",
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "stress_test_config = {\n",
+    "    \"run_name\": \"Onboarding Stress Test Run\", \n",
+    "    \"data_info\": {\n",
+    "        \"ref_dataset_id\": ref_dataset_id, \n",
+    "        \"eval_dataset_id\": eval_dataset_id,\n",
+    "    }, \n",
+    "    \"model_id\": model_id\n",
+    "}\n",
+    "stress_job = client.start_stress_test(\n",
+    "    stress_test_config, project.project_id, agent_id=AGENT_ID\n",
+    ")\n",
+    "stress_job.get_status(verbose=True, wait_until_finish=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "LFB5nVEaTtnB",
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "**Wait for a couple minutes and your results will appear in the UI.**"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "ovrKDoifIxIm",
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "## **Stress Test Results**\n",
+    "\n",
+    "Stress tests are grouped into categories that measure various aspects of model robustness (model behavior, distribution drift, abnormal input, transformations, adversarial attacks, data cleanliness). Suggestions to improve your model are aggregated on the category level as well. Tests are ranked by default by a shared severity metric. Clicking on an individual test surfaces more detailed information. \n",
+    "\n",
+    "\n",
+    "You can view the detailed results in the UI by running the below cell and redirecting to the generated link. This page shows granular results for a given AI Stress Test run. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "h2iYOcGiI16-",
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "test_run = stress_job.get_test_run()\n",
+    "test_run"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "1zKDo7TOYYds",
+    "pycharm": {
+     "name": "#%% md\n"
+    },
+    "tags": []
+   },
+   "source": [
+    "### **Analyzing the Results**\n",
+    "\n",
+    "Below you can see a snapshot of the results. \n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "h2jQYUDmknsU",
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "![img_2](https://drive.google.com/uc?id=126qw9YXDHzli_lj7XwyIi89U0FBVjMki)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "1oO26DNFoJQV",
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "Here are the results of the Subset Performance tests. These tests can be thought as more detailed performance tests that identify subsets of underperformance. These tests help ensure that the model works equally well across different groups."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "Nc1TzYeqkn1k",
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "![img_3](https://drive.google.com/uc?id=1ityHRKipkvMi8aU3nMS3Xb9ewrSUDhnx)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "EfnKH70fpmmu",
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "Below we are exploring the \"Subset Recall\" test cases for the feature \"City\". We can see that even though the model has a Recall of 0.81, it performs poorly on certain cities like Sao Paolo and Rio De Janeiro. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "g91I82zRkoH5",
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "![img_4](https://drive.google.com/uc?id=1epNLMxOVLVoiByCBJ-sCHM4QgopYEDYW)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "XGivw_Weookf",
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "### **Programmatically Querying the Results**"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "HB4A2GouWysL",
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "RIME not only provides you with an intuitive UI to visualize and explore these results, but also allows you to programmatically query these results. This allows customers to integrate with their MLOps pipeline, log results to experiment management tools like MLFlow, bring automated decision making to their ML practicies, or store these results for future references. \n",
+    "\n",
+    "Run the below cell to programmatically query the results. The results are outputed as a pandas dataframe."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "fTWLakM8VQj6",
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "**Access results at the a test run overview level**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "dgawCIZWLFST",
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "test_run_result = test_run.get_result_df()\n",
+    "test_run_result"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "tUUcNh7XVUPl",
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "**Access detailed test results at each individual test cases level.**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "u2qh2linVIt9",
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "test_case_result = test_run.get_test_cases_df()\n",
+    "test_case_result.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "5f7LPX1pqOhP",
+    "pycharm": {
+     "name": "#%% md\n"
+    },
+    "tags": []
+   },
+   "source": [
+    "## **Deploy to Production and set up Continuous Testing**\n",
+    "\n",
+    "Once you have identified the best stress test run, you can deploy the associated model and set up Continuous Testing in order to automatically detect “bad” incoming data and statistically significant distributional drift. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "from datetime import timedelta\n",
+    "\n",
+    "ct_instance = project.create_ct(model_id, ref_dataset_id, timedelta(days=1))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "a0Lw2YBXBkb4",
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "## **Uploading a Batch of Production Data & Model Predictions to Continuous Testing**\n",
+    "\n",
+    "The fraud detection model has been in production for 30 days. Production data and model predictions have been collected and stored for the past 30 days. Now, we will use Continuous Testing to track how the model performed across the last 30 days. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "g7McYwfDUztC",
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "**Upload the Latest Batch of Production Data**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "zsmlbMIFUzAy",
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "dt = str(datetime.now())\n",
+    "prod_s3_path = client.upload_file(\n",
+    "    Path('fraud/data/fraud_incremental.csv'), \n",
+    "    upload_path=upload_path\n",
+    ")\n",
+    "prod_dataset_id = project.register_dataset_from_file(\n",
+    "    f\"prod_dataset_{dt}\", \n",
+    "    prod_s3_path, \n",
+    "    data_params={\"label_col\": \"label\", \"timestamp_col\": \"timestamp\"},\n",
+    "    agent_id=AGENT_ID\n",
+    ")\n",
+    "prod_preds_s3_path = client.upload_file(\n",
+    "    Path('fraud/data/fraud_incremental_preds.csv'), \n",
+    "    upload_path=upload_path\n",
+    ")\n",
+    "project.register_predictions_from_file(\n",
+    "    prod_dataset_id, model_id, prod_preds_s3_path, agent_id=AGENT_ID\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "e-ooaBT-U4yr",
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "**Run Continuous Testing over Batch of Data**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "EHxteK1gUklo",
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "ct_job = ct_instance.start_continuous_test(prod_dataset_id, agent_id=AGENT_ID)\n",
+    "ct_job.get_status(verbose=True, wait_until_finish=True)\n",
+    "ct_instance"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "ifxKz_p6Uc63",
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "**Wait for a couple minutes and your results will appear in the UI.**"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "## **Querying Results from Continuous Testing**"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "After continuous testing has been created and data has been uploaded for processing, the user can query the results throughout the entire uploaded history."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "**Obtain All Detection Events**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "events = [d.to_dict() for m in ct_instance.list_monitors() for d in m.list_detected_events()]\n",
+    "events_df = pd.DataFrame(events).drop([\"id\", \"project_id\", \"firewall_id\", \"event_object_id\", \"description_html\", \"last_update_time\"], axis=1)\n",
+    "events_df.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "vmpxUnaLMn-u",
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "\n",
+    "## **CT Overview**\n",
+    "\n",
+    "The Overview page is the mission control for your model’s production deployment health. In it, you can see the status of continuous test runs and their metrics change over time.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "AFuGGg8uNtC2",
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "![img_5](https://drive.google.com/uc?id=18Q62IvDft4IEAba9Tm7unCoIle8y4NOv)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "MzMea8BUFOT1",
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "## **CT Results**\n",
+    "\n",
+    "The Continuous Tests operate at the batch level and provide a mechanism to monitor the health of ML deployments in production. They allow the user to understand when errors begin to occur and surface the underlying drivers of such errors. \n",
+    "\n",
+    "You can explore the results in the UI by running the below cell and redirecting to the generated link.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "Qndn2zUMLhJo",
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "ct_instance"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "## **Appendix**"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "## **Uploading a Model to RIME**\n",
+    "To be able to run certain tests, RIME needs query access to your model. To give RIME access, you'll need to write a Python file that implements the `predict_df(df: pd.DataFrame) -> np.ndarray` function, and upload that file (and any objects that it loads) to the platform. Here we provide an example model file, show you how to upload this file and the relevant model artifacts, and show you how to configure stress tests to use this model."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "%%writefile fraud/models/fraud_model.py\n",
+    "from pathlib import Path\n",
+    "\n",
+    "from catboost import CatBoostClassifier\n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "\n",
+    "\n",
+    "mod = CatBoostClassifier()\n",
+    "# Load our CatBoost model. Note that this requires us to\n",
+    "# upload fraud_model.catb along with this Python file,\n",
+    "# in the same directory.\n",
+    "mod.load_model(Path(__file__).parent / \"fraud_model.catb\")\n",
+    "cat_cols = [\n",
+    "    'category', \n",
+    "    'card_type', \n",
+    "    'card_company', \n",
+    "    'city', \n",
+    "    'browser_version', \n",
+    "    'country',\n",
+    "]\n",
+    "\n",
+    "def predict_df(df: pd.DataFrame) -> np.ndarray:\n",
+    "    \"\"\"Given data as a pandas DataFrame, return probabilities as a NumPy array.\"\"\"\n",
+    "    for col in cat_cols:\n",
+    "        df[col] = df[col].astype(object)\n",
+    "    # For binary classification we expect a one-dimensional\n",
+    "    # array for the probabilities, where the score for each datapoint\n",
+    "    # is the probability that the label is 1.\n",
+    "    return mod.predict_proba(df.fillna(0))[:,1]\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Note that 'fraud/models' directory already contains the 'fraud_model.catb' file.\n",
+    "appendix_model_dir = client.upload_directory(\n",
+    "    Path('fraud/models'), upload_path=upload_path\n",
+    ")\n",
+    "appendix_model_path = appendix_model_dir + \"/fraud_model.py\"\n",
+    "appendix_model_id = project.register_model_from_path(\n",
+    "    f\"appendix_model_{dt}\", appendix_model_path\n",
+    ")\n",
+    "stress_test_with_model_config = {\n",
+    "    \"run_name\": \"Uploaded Model Example\",\n",
+    "    \"data_info\": {\n",
+    "        \"ref_dataset_id\": ref_dataset_id, \n",
+    "        \"eval_dataset_id\": eval_dataset_id,\n",
+    "    },\n",
+    "    \"model_id\": appendix_model_id\n",
+    "}\n",
+    "stress_job = client.start_stress_test(\n",
+    "    stress_test_with_model_config, project.project_id, agent_id=AGENT_ID\n",
+    ")\n",
+    "stress_job.get_status(verbose=True, wait_until_finish=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "## **Running a Custom Test**\n",
+    "With RIME you can write your own custom tests, to encode any domain-specific validation you want to perform. These tests will run and be uploaded to the platform just like any of the built-in tests. To run a custom test you need to implement a specific interface in Python, upload the file to the platform, and point to it in your configuration. Below we provide a simple example of a custom test that checks if the difference in the length of the reference and evaluation datasets does not exceed some threshold."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "%%writefile fraud/custom_test.py\n",
+    "\"\"\"Custom test batch runner.\"\"\"\n",
+    "from typing import List, Tuple\n",
+    "from rime.core.schema.config import CustomConfig\n",
+    "from rime.core.schema.test_result import (\n",
+    "    ImportanceLevel,\n",
+    "    Status,\n",
+    "    TableColumn,\n",
+    "    TestBatchResult,\n",
+    "    TestOutput,\n",
+    ")\n",
+    "from rime.core.test import BaseTest, TestExtraInfo\n",
+    "from rime.core.stress_tests.batch_runner import DataTestBatchRunner\n",
+    "from rime.core.stress_tests.schema.test_result import TestBatchResult, TestOutput\n",
+    "from rime.core.profiler.run_containers import RunContainer\n",
+    "\n",
+    "# Signature should not be changed.\n",
+    "class CustomTest(BaseTest):\n",
+    "    def __init__(self, delta: int = 0):\n",
+    "        \"\"\"Initialize with a delta between n_rows ref and eval.\"\"\"\n",
+    "        super().__init__()\n",
+    "        self.delta = delta\n",
+    "\n",
+    "    # Signature should not be changed.\n",
+    "    def run(\n",
+    "        self, \n",
+    "        run_container: RunContainer,\n",
+    "        silent_errors: bool = False\n",
+    "    ) -> Tuple[TestOutput, TestExtraInfo]:\n",
+    "        ref_data_size = len(run_container.ref_data.df)\n",
+    "        eval_data_size = len(run_container.eval_data.df)\n",
+    "        if ref_data_size > eval_data_size + self.delta:\n",
+    "            status = Status.WARNING\n",
+    "            severity = ImportanceLevel.HIGH\n",
+    "        else:\n",
+    "            status = Status.PASS\n",
+    "            severity = ImportanceLevel.NONE\n",
+    "        test_output = TestOutput(\n",
+    "            self.id, status, {\"Severity\": severity}, severity, [],\n",
+    "        )\n",
+    "        return test_output, TestExtraInfo(severity)\n",
+    "\n",
+    "\n",
+    "# Signature should not be changed.\n",
+    "class CustomBatchRunner(DataTestBatchRunner):\n",
+    "    \"\"\"TestBatchRunner for the CustomTest.\"\"\"\n",
+    "\n",
+    "    # Signature should not be changed.\n",
+    "    @classmethod\n",
+    "    def _from_config(\n",
+    "        cls, run_container: RunContainer,  config: CustomConfig, category: str\n",
+    "    ) -> \"DataTestBatchRunner\":\n",
+    "        if config.params is None:\n",
+    "            delta = 0\n",
+    "        else:\n",
+    "            delta = config.params[\"delta\"]\n",
+    "        tests = [CustomTest(delta=delta)]\n",
+    "        return cls(tests, category)\n",
+    "\n",
+    "    # Signature should not be changed.\n",
+    "    def _outputs_to_batch_res(\n",
+    "        self,\n",
+    "        run_container: RunContainer,\n",
+    "        outputs: List[TestOutput],\n",
+    "        extra_infos: List[dict],\n",
+    "        duration: float,\n",
+    "    ) -> TestBatchResult:\n",
+    "        long_description_tabs = [\n",
+    "            {\"title\": \"Description\", \"contents\": self.long_description},\n",
+    "            {\"title\": \"Why it Matters\", \"contents\": \"Explain why this test matters.\"},\n",
+    "            {\n",
+    "                \"title\": \"Configuration\",\n",
+    "                \"contents\": \"Explain how this test is configured.\"\n",
+    "            },\n",
+    "            {\n",
+    "                \"title\": \"Example\",\n",
+    "                \"contents\": \"Include an example of how this test works.\"\n",
+    "            },\n",
+    "        ]\n",
+    "        return TestBatchResult(\n",
+    "            self.type,\n",
+    "            self.description,\n",
+    "            long_description_tabs,\n",
+    "            self.category,\n",
+    "            outputs,\n",
+    "            [],\n",
+    "            duration,\n",
+    "            extra_infos,\n",
+    "            [TableColumn(\"Severity\")],\n",
+    "            outputs[0].severity,\n",
+    "        )\n",
+    "\n",
+    "\n",
+    "    # Signature should not be changed.\n",
+    "    @property\n",
+    "    def description(self) -> str:\n",
+    "        return \"This is custom test\"\n",
+    "\n",
+    "    # Signature should not be changed.\n",
+    "    @property\n",
+    "    def long_description(self) -> str:\n",
+    "        return \"This is a long description of a custom test.\"\n",
+    "\n",
+    "    # Signature should not be changed.\n",
+    "    @property\n",
+    "    def type(self) -> str:\n",
+    "        return \"Example Custom Test\"\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "custom_test_path = client.upload_file(\"fraud/custom_test.py\", upload_path=upload_path)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "stress_test_with_model_config = {\n",
+    "    \"run_name\": \"Custom Test Example\",\n",
+    "    \"data_info\": {\n",
+    "        \"ref_dataset_id\": ref_dataset_id, \n",
+    "        \"eval_dataset_id\": eval_dataset_id,\n",
+    "    },\n",
+    "    \"test_suite_config\": {\n",
+    "        \"custom_tests\": [\n",
+    "            {\n",
+    "                \"custom_test_category\": \"Data Cleanliness\", \n",
+    "                \"test_path\": custom_test_path\n",
+    "            }\n",
+    "        ],\n",
+    "    },\n",
+    "    \"model_id\": model_id\n",
+    "}\n",
+    "stress_job = client.start_stress_test(\n",
+    "    stress_test_with_model_config, project.project_id, agent_id=AGENT_ID\n",
+    ")\n",
+    "stress_job.get_status(verbose=True, wait_until_finish=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "stress_job.get_test_run()"
+   ]
+  }
+ ],
+ "metadata": {
+  "colab": {
+   "collapsed_sections": [],
+   "name": "RIME_Fraud_OnboardingWalkthrough.ipynb",
+   "provenance": []
+  },
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.17"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/notebooks/demo_notebooks/RIME_Generative_Walkthrough.ipynb
+++ b/notebooks/demo_notebooks/RIME_Generative_Walkthrough.ipynb
@@ -1,0 +1,516 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# **RI Generative Stress Test Walkthrough**"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In this walkthrough, we will run RIME's Generative AI Stress Testing on OpenAI's Chat GPT model to demonstrate how RIME can be used with generative models. The data consists of sample text-generated information that a Chat GPT model would use as input and output which includes a title, context, question, answer, and prompt. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## **Install Dependencies, Import Libraries and Download Data**\n",
+    "Run the cell below to install libraries to receive data, install our SDK, and load analysis libraries."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install rime-sdk &> /dev/null"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "from pathlib import Path\n",
+    "from rime_sdk import Client"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Run the cell below to download and unzip a generated dataset and pre-trained model."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install https://github.com/RobustIntelligence/ri-public-examples/archive/master.zip    \n",
+    "from ri_public_examples.download_files import download_files\n",
+    "\n",
+    "download_files('generative/question_answering', 'question_answering') "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## **Establish the RIME Client**\n",
+    "\n",
+    "To get started, provide the API credentials and the base domain/address of the RIME service. You can generate and copy an API token from the API Access Tokens Page under Workspace settings. For the domian/address of the RIME service, contact your admin. \n",
+    "\n",
+    "![API_token](https://drive.google.com/uc?id=1zF1inyDbU2Q08SW9Ans2eVw0LqUnA2uP)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "API_TOKEN = '' # PASTE API_KEY \n",
+    "CLUSTER_URL = '' # PASTE DEDICATED DOMAIN OF RIME SERVICE (eg: rime.stable.rbst.io)\n",
+    "AGENT_ID = '' # PASTE AGENT_ID IF USING AN AGENT THAT IS NOT THE DEFAULT\n",
+    "\n",
+    "client = Client(CLUSTER_URL, API_TOKEN)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## **Create a New Project**\n",
+    "\n",
+    "You can create projects in RIME to organize your test runs. Each project represents a workspace for a given machine learning task. It can contain multiple candidate models, but should only contain one promoted production model. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "description = (\n",
+    "    \"Run Generative Stress Testing on a\"\n",
+    "    \" generative model and dataset. Demonstration uses\"\n",
+    "    \" a dataset composed of short scenarios that are each\"\n",
+    "    \" identifed by title and characterized by context,\"\n",
+    "    \" a question, an answer, and a prompt.\"\n",
+    ")\n",
+    "project = client.create_project(\n",
+    "    name=\"GAI Security Demo\", \n",
+    "    description=description, \n",
+    "    model_task=\"MODEL_TASK_QUESTION_ANSWERING\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Go back to the UI to see the new `Generative Model Stress Test Demo` project.**"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## **Register and Upload the Model + Dataset**\n",
+    "\n",
+    "We now want to kick off RIME Stress Tests that will help us evaluate the model in further depth beyond basic performance metrics like accuracy, precision, recall. In order to do this, we will upload this pre-trained model and the evaluation dataset the model was evaluated on to an S3 bucket that can be accessed by RIME. We also need to upload a fact sheet that will later be used to run the stress test. Futhermore, we'll need to register them with RIME."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "upload_path = \"ri_public_examples_generative\"\n",
+    "\n",
+    "model_s3_dir = client.upload_directory(\n",
+    "    Path('question_answering/models'), upload_path=upload_path\n",
+    ")\n",
+    "model_s3_path = model_s3_dir + \"/chat_gpt_model.py\"\n",
+    "\n",
+    "eval_s3_path = client.upload_file(\n",
+    "    Path('question_answering/data/squad_v2_test_with_labels.json'), upload_path=upload_path\n",
+    ")\n",
+    "\n",
+    "fact_sheet_path = client.upload_file(\n",
+    "    Path('question_answering/data/fact_sheet.txt'), upload_path=upload_path\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Once the data and model are uploaded to S3, we can register them to RIME. Once they're registered, we can refer to these resources using their RIME-generated ID's. We also need to obtain an integration ID from the workspace, which is then used to register the model and aid in stress test configuration."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from datetime import datetime\n",
+    "\n",
+    "dt = str(datetime.now())\n",
+    "\n",
+    "integration_id = client.create_integration(\n",
+    "    workspace_id=\"\", # PASTE WORKSPACE ID FROM INFO BUTTON ON WORKSPACE OVERVIEW PAGE\n",
+    "    name=f\"GAI_walkthrough_{dt}\",\n",
+    "    integration_type=\"INTEGRATION_TYPE_CUSTOM\", \n",
+    "    integration_schema=[\n",
+    "        {\n",
+    "            \"name\": \"OPENAI_API_KEY\",\n",
+    "            \"sensitivity\": \"VARIABLE_SENSITIVITY_WORKSPACE_SECRET\",\n",
+    "            \"value\": \"\", # FILL IN YOUR OPENAI API KEY HERE\n",
+    "        }\n",
+    "    ],\n",
+    ")\n",
+    "\n",
+    "# Note: models and datasets need to have unique names.\n",
+    "model_id = project.register_model(\n",
+    "    name=f\"model_{dt}\",\n",
+    "    model_config={\"generative_language_model\": {\n",
+    "        \"model_path\": model_s3_path,\n",
+    "        \"system_prompt\": \"I am ChatGPT, a large language model trained by OpenAI, based on the GPT-3.5 architecture.\\nKnowledge cutoff: 2021-09\\nCurrent date: 2023-03-28\"\n",
+    "    }},    \n",
+    "    model_endpoint_integration_id=integration_id,\n",
+    "    skip_validation=True\n",
+    ")\n",
+    "\n",
+    "data_params = {\n",
+    "    \"label_col\": \"answer\",\n",
+    "    \"prompt_col\": \"prompt\",\n",
+    "    \"text_features\": [\n",
+    "        \"context\",\n",
+    "        \"question\"]\n",
+    "}\n",
+    "eval_dataset_id = project.register_dataset(\n",
+    "    name=f\"eval_dataset_{dt}\",\n",
+    "    data_config={\n",
+    "        \"connection_info\": {\"data_file\": {\"path\": eval_s3_path}},\n",
+    "        \"data_params\":data_params\n",
+    "    }\n",
+    ")\n",
+    "\n",
+    "tests_config = {\n",
+    "    \"row_wise_factual_inconsistency\": {\"fact_sheet_path\": fact_sheet_path},\n",
+    "}\n",
+    "test_suite_config = {\"individual_tests_config\": tests_config}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## **Running a Generative Stress Test**\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "A Generative Stress Test allows you to test your data and model before deployment. They are a comprehensive suite of hundreds of tests that automatically identify implicit assumptions and weaknesses of pre-production models. Each stress test is run on a single model and displays corresponding results."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Below is a sample configuration of how to setup and run a RIME Generative Stress Test. This configuration specifies relevant metadata for our dataset and model to run the stress test."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "generative_stress_test_config = {\n",
+    "    \"run_name\":\"GPT-3.5\", \n",
+    "    \"model_task\":\"Question Answering\",\n",
+    "    \"model_id\":model_id,\n",
+    "    \"eval_dataset_id\":eval_dataset_id,\n",
+    "    \"integration_id\":{\"uuid\": integration_id},\n",
+    "    \"run_time_info\":{\"explicit_errors\":False},\n",
+    "    \"test_suite_config\":test_suite_config,\n",
+    "    \"categories\": [\n",
+    "        \"TEST_CATEGORY_TYPE_ADVERSARIAL\",\n",
+    "        \"TEST_CATEGORY_TYPE_DATA_POISONING_DETECTION\",\n",
+    "        \"TEST_CATEGORY_TYPE_SUBSET_PERFORMANCE\",\n",
+    "        \"TEST_CATEGORY_TYPE_TRANSFORMATIONS\",\n",
+    "        \"TEST_CATEGORY_TYPE_EVASION_ATTACK_DETECTION\",\n",
+    "        \"TEST_CATEGORY_TYPE_MODEL_ALIGNMENT\",\n",
+    "        \"TEST_CATEGORY_TYPE_FACTUAL_AWARENESS\",\n",
+    "        \"TEST_CATEGORY_TYPE_BIAS_AND_FAIRNESS\"\n",
+    "    ]\n",
+    "}\n",
+    "\n",
+    "stress_job = client._start_generative_stress_test(\n",
+    "    test_run_config=generative_stress_test_config,\n",
+    "    project_id=project.project_id\n",
+    ")\n",
+    "stress_job.get_status(verbose=True, wait_until_finish=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## **Generative Stress Test Results**"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Generative Stress Test Results are grouped into categories that measure various aspects of generative model robustness (adverserial, transformations, model alignment, subset performance). These categories are what determine production readiness. Suggestions to improve your model are aggregated on the category level as well. Tests are ranked by default by a shared severity metric. Clicking on an individual test surfaces more detailed information.\n",
+    "\n",
+    "You can view the detailed results in the UI by running the below cell and redirecting to the generated link. This page shows granular results for a given AI Generative Stress Test run."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "test_run = stress_job.get_test_run()\n",
+    "test_run"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### **Analyzing the Results**\n",
+    "\n",
+    "Below you can see a snapshot of the results. "
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "![stress_test.png](https://drive.google.com/uc?id=1Tyn3QHU7UM9EMgE3S7WngGSEW-2Mv4BR)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Notice that each test result category articulates status of the model with respect to the category. Under each category description is a list of any 'Data Requirements' for that category to run successfully.\n",
+    "\n",
+    "Here are the results of the \"Transformations\" tests. These tests augment your evaluation dataset with synthetic abnormal values to proactively test your pipeline’s error-handling behavior and measure the performance degradation caused by different types of abnormal values. "
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "![transformations_category](https://drive.google.com/uc?id=17Ggnf2fw4p3SteTtfitd6l3ZuHxO6eMH)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Below we are exploring the \"Generative Synonym Swap\" test cases. This test measures the robustness of your model to synonym swap transformations. It does this by randomly swapping synonyms in the input string and measuring the difference in model outputs between the original input and the transformed input. For the first test case, we can see the SBERT Score, which measures similarity between the original and transformed outputs, is 0.64. This means that our model has changed its output significantly and is likely not robust to synonym swaps."
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "![datapoint_details.png](https://drive.google.com/uc?id=19KHVhZaYhm2uv8edqJdTJg0WNef0vMof)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### **Programmatically Querying the Results**"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "RIME not only provides you with an intuitive UI to visualize and explore these results, but also allows you to programmatically query these results. This allows customers to integrate with their MLOps pipeline, log results to experiment management tools like MLFlow, bring automated decision making to their ML practices, or store these results for future references. \n",
+    "\n",
+    "Run the below cell to programmatically query the results. The results are outputed as a pandas dataframe."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Access results at the test run overview level**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "test_run_result = test_run.get_result_df()\n",
+    "test_run_result.to_csv(\"QA_Test_Run_Results.csv\")\n",
+    "test_run_result"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Access detailed test results at each individual test cases level.**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "test_case_result = test_run.get_test_cases_df()\n",
+    "test_case_result.to_csv(\"QA_Test_Run_Results.csv\")\n",
+    "test_case_result.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## **Appendix**"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### **Uploading a Model to RIME**\n",
+    "To be able to run certain tests, RIME needs query access to your model. To give RIME access, you'll need to write a Python file that implements the `generate(system_prompt: str, prompt: str) -> str` function, and upload that file (and any objects that it loads) to the platform. Here we provide an example model file, show you how to upload this file and the relevant model artifacts, and show you how to configure stress tests to use this model."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%writefile question_answering/models/FLAN_T5_base.py\n",
+    "from pathlib import Path\n",
+    "\n",
+    "from transformers import AutoModelForSeq2SeqLM, AutoTokenizer\n",
+    "\n",
+    "# Load FLAN-T5-base model\n",
+    "tokenizer = AutoTokenizer.from_pretrained(\"google/flan-t5-base\")\n",
+    "model = AutoModelForSeq2SeqLM.from_pretrained(\"google/flan-t5-base\")\n",
+    "\n",
+    "def generate(system_prompt: str, prompt: str) -> str:\n",
+    "    \"\"\"Given a system prompt and prompt, return the response as a string.\"\"\"\n",
+    "    text = f\"{system_prompt}\\n{prompt}\"\n",
+    "    input_ids = tokenizer(text, return_tensors=\"pt\").input_ids\n",
+    "    outputs = model.generate(input_ids, max_new_tokens=100)\n",
+    "    decoded = tokenizer.decode(outputs[0])\n",
+    "    return decoded"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from datetime import datetime\n",
+    "\n",
+    "dt = str(datetime.now())\n",
+    "\n",
+    "appendix_model_dir = client.upload_directory(\n",
+    "    Path('question_answering/models'), upload_path=upload_path\n",
+    ")\n",
+    "appendix_model_path = appendix_model_dir + \"/FLAN_T5_base.py\"\n",
+    "# Note: models need to have unique names\n",
+    "appendix_model_id = project.register_model(\n",
+    "    name=f\"appendix_model_{dt}\",\n",
+    "    model_config={\"generative_language_model\": {\n",
+    "        \"model_path\": appendix_model_path,\n",
+    "        \"system_prompt\": \"I am a Hugging Face language model.\"\n",
+    "    }},\n",
+    "    skip_validation=True\n",
+    ")\n",
+    "\n",
+    "appendix_fact_sheet_path = client.upload_file(\n",
+    "    Path('question_answering/data/fact_sheet.txt'), upload_path=upload_path\n",
+    ")\n",
+    "appendix_tests_config = {\n",
+    "    \"row_wise_factual_inconsistency\": {\"fact_sheet_path\": appendix_fact_sheet_path},\n",
+    "}\n",
+    "appendix_test_suite_config = {\"individual_tests_config\": appendix_tests_config}\n",
+    "\n",
+    "stress_test_with_model_config = {\n",
+    "    \"run_name\":\"Uploaded Model Example\", \n",
+    "    \"model_task\":\"Question Answering\",\n",
+    "    \"model_id\":appendix_model_id,\n",
+    "    \"eval_dataset_id\":eval_dataset_id,\n",
+    "    \"run_time_info\":{\"explicit_errors\":False},\n",
+    "    \"test_suite_config\":appendix_test_suite_config,\n",
+    "    \"categories\": [\n",
+    "        \"TEST_CATEGORY_TYPE_ADVERSARIAL\",\n",
+    "        \"TEST_CATEGORY_TYPE_DATA_POISONING_DETECTION\",\n",
+    "        \"TEST_CATEGORY_TYPE_SUBSET_PERFORMANCE\",\n",
+    "        \"TEST_CATEGORY_TYPE_TRANSFORMATIONS\",\n",
+    "        \"TEST_CATEGORY_TYPE_EVASION_ATTACK_DETECTION\",\n",
+    "        \"TEST_CATEGORY_TYPE_MODEL_ALIGNMENT\",\n",
+    "        \"TEST_CATEGORY_TYPE_FACTUAL_AWARENESS\",\n",
+    "        \"TEST_CATEGORY_TYPE_BIAS_AND_FAIRNESS\"\n",
+    "    ]\n",
+    "}\n",
+    "stress_job = client._start_generative_stress_test(\n",
+    "    test_run_config=stress_test_with_model_config,\n",
+    "    project_id=project.project_id\n",
+    ")\n",
+    "stress_job.get_status(verbose=True, wait_until_finish=True)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.17"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/notebooks/demo_notebooks/RIME_Images_Walkthrough.ipynb
+++ b/notebooks/demo_notebooks/RIME_Images_Walkthrough.ipynb
@@ -1,0 +1,804 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "4a30e086",
+   "metadata": {
+    "id": "4a30e086"
+   },
+   "source": [
+    "# **RI Image Classification Walkthrough**"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2a62b333",
+   "metadata": {
+    "id": "2a62b333"
+   },
+   "source": [
+    "> ▶️ **Try this in Colab!** Run the [RI Image Classification Walkthrough in Google Colab](https://colab.research.google.com/github/RobustIntelligence/docs/blob/main/notebooks/demo_notebooks/RIME_Images_Walkthrough.ipynb).\n",
+    "\n",
+    "You are a data scientist working for a wildlife research foundation. The data science team has been tasked with implementing an animal classifier and monitoring how that model performs over time. The performance of this  model directly impacts the profits of the foundation. In order to ensure the data science team develops the best model and the performance of this model doesn't degrade over time, the VP of Data Science purchases the RIME platform.\n",
+    "\n",
+    "In this Notebook Walkthrough, we will walkthrough 2 of RIME's core products - **AI Stress Testing** and **AI Continuous Testing**.\n",
+    "\n",
+    "1. **AI Stress Testing** is used in the model development stage. Using AI Stress Testing you can test the developed model. RIME goes beyond simply optimizing for basic model performance like accuracy and automatically discovers the model's weaknesses.\n",
+    "2. **AI Continuous Testing** is used after the model is deployed in production. Using AI Continuous Testing, you can automate the monitoring, discovery and remediation of issues that occur post-deployment."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "583413e8",
+   "metadata": {
+    "id": "583413e8"
+   },
+   "source": [
+    "## **Install Dependencies, Import Libraries and Download Data**"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b9d4e307",
+   "metadata": {
+    "id": "b9d4e307"
+   },
+   "source": [
+    "Run the cell below to install libraries to prep data, install our SDK, and load analysis libraries."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2f86e16d",
+   "metadata": {
+    "id": "2f86e16d"
+   },
+   "outputs": [],
+   "source": [
+    "!pip install rime-sdk &> /dev/null"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9b444671",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from rime_sdk import Client"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6-k0PD26CaRb",
+   "metadata": {
+    "id": "6-k0PD26CaRb"
+   },
+   "outputs": [],
+   "source": [
+    "!pip install https://github.com/RobustIntelligence/ri-public-examples/archive/master.zip\n",
+    "    \n",
+    "from ri_public_examples.download_files import download_files\n",
+    "\n",
+    "download_files(\"images/classification/awa2\", \"awa2\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4a7d2a42",
+   "metadata": {
+    "id": "4a7d2a42"
+   },
+   "source": [
+    "## **Establish the RIME Client**"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c9b267b0",
+   "metadata": {
+    "id": "c9b267b0"
+   },
+   "source": [
+    "To get started, provide the API credentials and the base domain/address of the RIME Cluster. You can generate and copy an API token from the API Access Tokens Page under Workspace settings. For the domain/address of the RIME Cluster, contact your admin."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6a594b58",
+   "metadata": {},
+   "source": [
+    "![img_1](https://drive.google.com/uc?id=1vMDhZii8yq22iuqSM8-Vqt3sZ2F3tPyz)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b0d848e6",
+   "metadata": {
+    "id": "b0d848e6"
+   },
+   "outputs": [],
+   "source": [
+    "API_TOKEN = '' # PASTE API_KEY \n",
+    "CLUSTER_URL = '' # PASTE DEDICATED DOMAIN OF RIME SERVICE (eg: rime.stable.rbst.io)\n",
+    "AGENT_ID = '' # PASTE AGENT_ID IF USING AN AGENT THAT IS NOT THE DEFAULT\n",
+    "rime_client = Client(CLUSTER_URL, API_TOKEN)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "523277d9",
+   "metadata": {
+    "id": "523277d9"
+   },
+   "source": [
+    "## **Create a New Project**"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3f56f17c",
+   "metadata": {
+    "id": "3f56f17c"
+   },
+   "source": [
+    "You can create projects in RIME to organize your test runs. Each project represents a workspace for a given machine learning task. It can contain multiple candidate models, but should only contain one promoted production model."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "451db172",
+   "metadata": {
+    "id": "451db172"
+   },
+   "outputs": [],
+   "source": [
+    "description = (\n",
+    "    \"Run Stress Testing and Continuous Testing on an \"\n",
+    "    \"image classification model and dataset. Demonstration uses \"\n",
+    "    \"the Animals with Attributes 2 (AwA2) dataset.\"\n",
+    ")\n",
+    "project = rime_client.create_project(\n",
+    "    'Image Classification Demo', \n",
+    "    description,\n",
+    "    \"MODEL_TASK_MULTICLASS_CLASSIFICATION\",\n",
+    ")\n",
+    "project"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a03c7ae7",
+   "metadata": {
+    "id": "a03c7ae7"
+   },
+   "source": [
+    "**Go back to the UI or click on the link above to see the Project**"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9dbc9b57",
+   "metadata": {
+    "id": "9dbc9b57"
+   },
+   "source": [
+    "## **Uploading the Datasets + Predictions**"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c7892bf2",
+   "metadata": {
+    "id": "c7892bf2"
+   },
+   "source": [
+    "For this demo, we are going to use the predictions of a image classification model for animals. The dataset we will be using is from Animals With Attributes 2 (AWA2), a benchmarking image dataset that records features and labels for numerous animals in the wild. The model you have trained is a ResNet designed to predict on the images in this diverse dataset.\n",
+    "\n",
+    "The model classifies an image  into a number of different categories such as - \n",
+    "\n",
+    "1. Sheep\n",
+    "2. Killer Whale\n",
+    "3. Monkey\n",
+    "\n",
+    "We now want to kick off RIME Stress Tests that will help us evaluated the model in further depth beyond basic performance metrics like accuracy, precision, recall. In order to do this, we will upload this pre-trained model, the reference dataset the model was trained on, and the evaluation dataset the model was evaluated on to an S3 bucket that can be accessed by RIME."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2852fa32",
+   "metadata": {
+    "id": "2852fa32"
+   },
+   "outputs": [],
+   "source": [
+    "upload_path = \"ri_public_examples_awa2\"\n",
+    "rime_models_directory = rime_client.upload_directory(\"awa2/models\", upload_path=upload_path)\n",
+    "rime_model_path = rime_models_directory + \"/model.py\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "81104593",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from datetime import datetime\n",
+    "\n",
+    "dt = str(datetime.now())\n",
+    "\n",
+    "# All registered resources need to have unique names, so we append the current\n",
+    "# timestamp in case this notebook is rerun.\n",
+    "model_id = project.register_model_from_path(f\"model_{dt}\", rime_model_path, agent_id=AGENT_ID)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ed4a4e64",
+   "metadata": {
+    "id": "ed4a4e64"
+   },
+   "outputs": [],
+   "source": [
+    "train_inputs_file = \"awa2/data/train_inputs_trial.json\"\n",
+    "test_inputs_file = \"awa2/data/test_inputs_trial.json\"\n",
+    "_, train_inputs_path = rime_client.upload_local_image_dataset_file(\n",
+    "    train_inputs_file, [\"image_path\"], upload_path=upload_path\n",
+    ")\n",
+    "_, test_inputs_path = rime_client.upload_local_image_dataset_file(\n",
+    "    test_inputs_file, [\"image_path\"], upload_path=upload_path\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a3d12569",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class_names = [\n",
+    "    \"antelope\", \n",
+    "    \"grizzly+bear\", \n",
+    "    \"killer+whale\", \n",
+    "    \"beaver\", \n",
+    "    \"dalmatian\", \n",
+    "    \"horse\", \n",
+    "    \"german+shepherd\", \n",
+    "    \"blue+whale\", \n",
+    "    \"siamese+cat\", \n",
+    "    \"skunk\", \n",
+    "    \"mole\", \n",
+    "    \"tiger\", \n",
+    "    \"moose\", \n",
+    "    \"spider+monkey\", \n",
+    "    \"elephant\", \n",
+    "    \"gorilla\", \n",
+    "    \"ox\", \n",
+    "    \"fox\", \n",
+    "    \"sheep\", \n",
+    "    \"hamster\", \n",
+    "    \"squirrel\", \n",
+    "    \"rhinoceros\", \n",
+    "    \"rabbit\", \n",
+    "    \"bat\", \n",
+    "    \"giraffe\", \n",
+    "    \"wolf\", \n",
+    "    \"chihuahua\", \n",
+    "    \"weasel\", \n",
+    "    \"otter\", \n",
+    "    \"buffalo\", \n",
+    "    \"zebra\", \n",
+    "    \"deer\", \n",
+    "    \"bobcat\", \n",
+    "    \"lion\", \n",
+    "    \"mouse\", \n",
+    "    \"polar+bear\", \n",
+    "    \"collie\", \n",
+    "    \"walrus\", \n",
+    "    \"cow\", \n",
+    "    \"dolphin\",\n",
+    "]\n",
+    "data_info = {\n",
+    "    \"image_features\": [\"image_path\"], \n",
+    "    \"label_col\": \"label\", \n",
+    "    \"class_names\": class_names,\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "584a9995",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ref_id = project.register_dataset_from_file(\n",
+    "    f\"ref_set_{dt}\", \n",
+    "    train_inputs_path, \n",
+    "    data_info,\n",
+    "    agent_id=AGENT_ID\n",
+    ")\n",
+    "eval_id = project.register_dataset_from_file(\n",
+    "    f\"eval_set_{dt}\", \n",
+    "    test_inputs_path, \n",
+    "    data_info,\n",
+    "    agent_id=AGENT_ID\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "46021f88",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ref_preds_path = rime_client.upload_file(\"awa2/data/train_preds_trial.json\")\n",
+    "eval_preds_path = rime_client.upload_file(\"awa2/data/test_preds_trial.json\")\n",
+    "project.register_predictions_from_file(\n",
+    "    ref_id, model_id, ref_preds_path, agent_id=AGENT_ID\n",
+    "    )\n",
+    "project.register_predictions_from_file(\n",
+    "    eval_id, model_id, eval_preds_path, agent_id=AGENT_ID\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b2092e00",
+   "metadata": {
+    "id": "b2092e00"
+   },
+   "source": [
+    "## **Running a Stress Test**"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0961a84d",
+   "metadata": {
+    "id": "0961a84d"
+   },
+   "source": [
+    "AI Stress Tests allow you to test your data and model before deployment. \n",
+    "They are a comprehensive suite of hundreds of tests that automatically identify implicit assumptions and weaknesses of pre-production models. Each stress test is run on a single model and its associated reference and evaluation datasets."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4f5a059f",
+   "metadata": {
+    "id": "4f5a059f"
+   },
+   "source": [
+    "Below is a sample configuration of how to setup and run a RIME Stress Test for Images."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d9a44de2",
+   "metadata": {
+    "id": "d9a44de2"
+   },
+   "outputs": [],
+   "source": [
+    "stress_test_config = {\n",
+    "    \"run_name\": \"Image Classification AWA2\",\n",
+    "    \"data_info\": {\n",
+    "        \"ref_dataset_id\": ref_id,\n",
+    "        \"eval_dataset_id\": eval_id,\n",
+    "    },\n",
+    "    \"model_id\": model_id,\n",
+    "    \"categories\": [\n",
+    "        \"TEST_CATEGORY_TYPE_TRANSFORMATIONS\",\n",
+    "        \"TEST_CATEGORY_TYPE_ADVERSARIAL\",\n",
+    "        \"TEST_CATEGORY_TYPE_SUBSET_PERFORMANCE\",\n",
+    "        \"TEST_CATEGORY_TYPE_DRIFT\",\n",
+    "    ]\n",
+    "}\n",
+    "stress_job = rime_client.start_stress_test(stress_test_config, project.project_id, agent_id=AGENT_ID)\n",
+    "stress_job.get_status(verbose=True, wait_until_finish=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ea8f1d8d",
+   "metadata": {
+    "id": "ea8f1d8d"
+   },
+   "source": [
+    "## **Stress Test Results**"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cc28ba9e",
+   "metadata": {
+    "id": "cc28ba9e"
+   },
+   "source": [
+    "Stress tests are grouped into categories that measure various aspects of model robustness (subset performance, distribution drift, adversarial, transformations). Suggestions to improve your model are aggregated on the category level as well. Tests are ranked by default by a shared severity metric. Clicking on an individual test surfaces more detailed information.\n",
+    "\n",
+    "You can view the detailed results in the UI by running the below cell and redirecting to the generated link. This page shows granular results for a given AI Stress Test run."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3fb39c39",
+   "metadata": {
+    "id": "3fb39c39"
+   },
+   "outputs": [],
+   "source": [
+    "test_run = stress_job.get_test_run()\n",
+    "test_run"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b18fcdc6",
+   "metadata": {
+    "id": "b18fcdc6"
+   },
+   "source": [
+    "### Analyzing the Results"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cdd5847d",
+   "metadata": {
+    "id": "cdd5847d"
+   },
+   "source": [
+    "Below you can see a snapshot of the results. Some of these tests such as the Subset Performance Tests analyze how your model performs on different groups properties related to your data, while others such as Transformations Tests analyze how your model reacts to augmented and perturbed images."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f37a686d",
+   "metadata": {},
+   "source": [
+    "![stress.png](https://drive.google.com/uc?id=1UUd44H194ZXSQXvIZWz_OSgHSuhUxRP8)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ee009241",
+   "metadata": {
+    "id": "ee009241"
+   },
+   "source": [
+    "#### Subset Performance Tests"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1f6dd569",
+   "metadata": {
+    "id": "1f6dd569"
+   },
+   "source": [
+    "Here are the results of the Subset Performance tests. These tests can be thought as more detailed performance tests that identify subsets of underperformance in your images metadata. These tests help ensure that the model works equally well across different styles of images."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6c46fd87",
+   "metadata": {},
+   "source": [
+    "![subset.png](https://drive.google.com/uc?id=1vyZ8H0eOlQluNE44aBY4TbQ1osxrR5xO)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ac44c948",
+   "metadata": {
+    "id": "ac44c948"
+   },
+   "source": [
+    "Below we are exploring the \"Subset F1 score\" test cases for the image metadata feature `ImageBrightness`. We can see that even though the model has an overall F1 score of 0.52, it performs poorly on images at the tails of the brightness distribution - images that are either very dim or very bright."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a458abb9",
+   "metadata": {},
+   "source": [
+    "![f1.png](https://drive.google.com/uc?id=1T1dqEg7Nu5XEsS_w9isIBYimSY6mACMx)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cbe2f10e",
+   "metadata": {
+    "id": "cbe2f10e"
+   },
+   "source": [
+    "#### Transformation Tests"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5c4c5f5c",
+   "metadata": {
+    "id": "5c4c5f5c"
+   },
+   "source": [
+    "The results of the transformation tests are below. These tests can be thought as ways to test your models response to augmented image data, which can often occur in reality. They help to make sure that your model is invariant to such changes in your data."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b38e0e18",
+   "metadata": {},
+   "source": [
+    "![transform.png](https://drive.google.com/uc?id=16aDLm0j9dXA99Q7N4jvvFB60Lo87IhzV)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "247e0e5e",
+   "metadata": {
+    "id": "247e0e5e"
+   },
+   "source": [
+    "### Programatically Querying the Results"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9b98c0c5",
+   "metadata": {
+    "id": "9b98c0c5"
+   },
+   "source": [
+    "RIME not only provides you with an intuitive UI to visualize and explore these results, but also allows you to programmatically query these results. This allows customers to integrate with their MLOps pipeline, log results to experiment management tools like MLFlow, bring automated decision making to their ML practicies, or store these results for future references.\n",
+    "\n",
+    "Run the below cell to programmatically query the results. The results are outputed as a pandas dataframe."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e0cb933b",
+   "metadata": {
+    "id": "e0cb933b"
+   },
+   "source": [
+    "**Access results at the a test run overview level**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "61614d6f",
+   "metadata": {
+    "id": "61614d6f"
+   },
+   "outputs": [],
+   "source": [
+    "test_run_result = test_run.get_result_df()\n",
+    "test_run_result.to_csv(\"AWA2_Test_Run_Results.csv\")\n",
+    "test_run_result"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1193cdf0",
+   "metadata": {
+    "id": "1193cdf0"
+   },
+   "source": [
+    "**Access detailed test results at each individual test cases level**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "92db7b45",
+   "metadata": {
+    "id": "92db7b45"
+   },
+   "outputs": [],
+   "source": [
+    "test_case_result = test_run.get_test_cases_df()\n",
+    "test_case_result.to_csv(\"AWA2_Test_Case_Results.csv\")\n",
+    "test_case_result"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "718e34b3",
+   "metadata": {
+    "id": "718e34b3"
+   },
+   "source": [
+    "## **Deploy to Production and set up Continuous Testing**\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1c1740c7",
+   "metadata": {
+    "id": "1c1740c7"
+   },
+   "source": [
+    "Once you have identified the best stress test run, you can deploy the associated model and set up Continuous Testing in order to automatically detect “bad” incoming data and statistically significant distributional drift. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3372f8f4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from datetime import timedelta\n",
+    "\n",
+    "ct_instance = project.create_ct(model_id, ref_id, timedelta(days=1))\n",
+    "ct_instance"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8b051fee",
+   "metadata": {
+    "id": "8b051fee"
+   },
+   "source": [
+    "## **Uploading a Batch of Production Data with Model Predictions to Continuous Testing**\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e5e75c2f",
+   "metadata": {
+    "id": "e5e75c2f"
+   },
+   "source": [
+    "The image classification model has been in production for the past week. Production data and model predictions have been collected and stored for the past two weeks. Now, we will use Continuous Testing to track how the model performed across the last two week."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6ec21cde",
+   "metadata": {
+    "id": "6ec21cde"
+   },
+   "source": [
+    "**Upload an Incremental Batch of Data**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a6328c42",
+   "metadata": {
+    "id": "a6328c42"
+   },
+   "outputs": [],
+   "source": [
+    "monitoring_inputs_file = \"awa2/data/test_inputs_monitoring_trial.json\"\n",
+    "_, monitoring_inputs_path = rime_client.upload_local_image_dataset_file(\n",
+    "    monitoring_inputs_file, [\"image_path\"], upload_path=upload_path)\n",
+    "monitoring_id = project.register_dataset_from_file(f\"monitoring_set_{dt}\", monitoring_inputs_path, {\"image_features\": [\"image_path\"], \"label_col\": \"label\", \"class_names\": class_names, \"timestamp_col\": \"timestamp\"}, agent_id=AGENT_ID)\n",
+    "\n",
+    "monitoring_preds_path = rime_client.upload_file(\"awa2/data/monitoring_preds_trial.json\")\n",
+    "project.register_predictions_from_file(\n",
+    "    monitoring_id, model_id, monitoring_preds_path, agent_id=AGENT_ID\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "12b95ad6",
+   "metadata": {
+    "id": "12b95ad6"
+   },
+   "source": [
+    "**Run Continuous Testing over Batch of Data**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a4fda2ea",
+   "metadata": {
+    "id": "a4fda2ea"
+   },
+   "outputs": [],
+   "source": [
+    "ct_job = ct_instance.start_continuous_test(monitoring_id, override_existing_bins=True, agent_id=AGENT_ID)\n",
+    "ct_job.get_status(verbose=True, wait_until_finish=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9d093020",
+   "metadata": {
+    "id": "9d093020"
+   },
+   "source": [
+    "**Wait for a couple minutes and your results will appear in the UI**"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "634b36f0",
+   "metadata": {
+    "id": "634b36f0"
+   },
+   "source": [
+    "## **CT Results**"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d9d89bf0",
+   "metadata": {
+    "id": "d9d89bf0"
+   },
+   "source": [
+    "The Continuous Tests operate at the batch level and provide a mechanism to monitor the health of ML deployments in production. They allow the user to understand when errors begin to occur and surface the underlying drivers of such errors.\n",
+    "\n",
+    "You can explore the results in the UI by running the below cell and redirecting to the generated link"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a0cb8e06",
+   "metadata": {
+    "id": "a0cb8e06"
+   },
+   "outputs": [],
+   "source": [
+    "ct_instance"
+   ]
+  }
+ ],
+ "metadata": {
+  "colab": {
+   "collapsed_sections": [
+    "b18fcdc6",
+    "ee009241",
+    "cbe2f10e",
+    "718e34b3",
+    "8512332c",
+    "51fc29d0"
+   ],
+   "name": "RIME_Images_Walkthrough.ipynb",
+   "provenance": []
+  },
+  "gpuClass": "standard",
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/demo_notebooks/RIME_Lending_Classification_Walkthrough.ipynb
+++ b/notebooks/demo_notebooks/RIME_Lending_Classification_Walkthrough.ipynb
@@ -1,0 +1,811 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "K05kWwxAT9uN",
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "# **RI Lending Classification Walkthrough**\n",
+    "\n",
+    "> ▶️ **Try this in Colab!** Run the [RI Lending Classification Walkthrough in Google Colab](https://colab.research.google.com/github/RobustIntelligence/docs/blob/main/notebooks/demo_notebooks/RIME_Lending_Classification_Walkthrough.ipynb). \n",
+    "\n",
+    "You are a data scientist at a Bank. The data science team has been tasked with implementing a binary classification model to predict whether an individual will default on a loan. The goal of this project is two-fold: we want to monitor how that model performs over time as well as ensure that the model is compliant with financial regulations. In order to accomplish the latter, we will be testing whether the model is biased against certain protected features. One could imagine such models being used downstream for various purposes, such as loan approval or funding allocation. A biased model could yield disadvantageous outcomes for protected groups. For instance, we may find that an individual with a specific race or race/gender combination causes the model to consistently predict a higher probability of them defaulting, causing a higher rate of loan rejection.\n",
+    "    \n",
+    "\n",
+    "In this Notebook Walkthrough, we will walkthrough our core products of **AI Stress Testing** and **AI Continuous Testing** in a *Bias and Fairness* setting. RIME AI Stress Testing allows you to test the developed model and datasets. With this compliance-focused setting, you will be able to verify your AI model for bias and fairness issues. RIME AI Continuous Testing allows you to continue monitoring your deployed model for bias."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "APMTB6F7byjr",
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "## **Install Dependencies, Import Libraries and Download Data**\n",
+    "Run the cell below to install libraries to recieve data, install our SDK, and load analysis libraries."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "-Qr8pHVOcNz7",
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "!pip install rime-sdk &> /dev/null"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "f03qjornDwbr",
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "from pathlib import Path\n",
+    "from rime_sdk import Client"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "UnbHm8sJYHUD",
+    "outputId": "b8ec9a17-2b4c-482b-ff1d-363c1530b384",
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "!pip install https://github.com/RobustIntelligence/ri-public-examples/archive/master.zip \n",
+    "from ri_public_examples.download_files import download_files\n",
+    "download_files('tabular-2.0/lending', 'lending')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "90zo7hdkmKyW",
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "## **Establish the RIME Client**\n",
+    "\n",
+    "To get started, provide the API credentials and the base domain/address of the RIME service. You can generate and copy an API token from the API Access Tokens Page under Workspace settings. For the domian/address of the RIME service, contact your admin. \n",
+    "\n",
+    "![img_1](https://drive.google.com/uc?id=1vMDhZii8yq22iuqSM8-Vqt3sZ2F3tPyz)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "Ns6m8I-qsCzF",
+    "outputId": "266cee4c-bcab-4d19-a6bc-eb6789e62202",
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "API_TOKEN = '' # PASTE API_KEY \n",
+    "CLUSTER_URL = '' # PASTE DEDICATED DOMAIN OF RIME SERVICE (eg: rime.stable.rbst.io)\n",
+    "AGENT_ID = '' # PASTE AGENT_ID IF USING AN AGENT THAT IS NOT THE DEFAULT"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "client = Client(CLUSTER_URL, API_TOKEN)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "pIjQx9KUvWCF",
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "## **Create a New Project**\n",
+    "\n",
+    "You can create projects in RIME to organize your test runs. Each project represents a workspace for a given machine learning task. It can contain multiple candidate models, but should only contain one promoted production model.  "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "YEghhVY8vy6K",
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "description = (\n",
+    "    \"Run Stress Testing and Continuous Testing on a tabular\"\n",
+    "    \" binary classification model and dataset.\"\n",
+    "    \" Demonstration uses the Lending Club dataset, which is used\"\n",
+    "    \" to predict whether someone will repay a loan.\"\n",
+    ")\n",
+    "project = client.create_project(\n",
+    "    name=\"Lending Classification Continuous Testing Demo\", \n",
+    "    description=description,\n",
+    "    model_task=\"MODEL_TASK_BINARY_CLASSIFICATION\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 35
+    },
+    "id": "4CQU6vkeDwbz",
+    "outputId": "425104d7-8340-4957-ab40-0d581af953e7",
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "project.project_id"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "eXZ6e7kiTit6",
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "**Go back to the UI to see the new `Lending Classification Continuous Testing Demo` project.**"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "3lsxeLehwN7Y",
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "## **Training a Lending Model and Uploading the Model + Datasets**\n",
+    "\n",
+    "Let's first take a lot at what the dataset looks like. We can observe that the data consists of a mix of categorical and numeric features."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pd.read_csv('lending/data/ref.csv').head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "6Mbokt95ZPfe",
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "For this demo, we are going to use a pretrained CatBoostClassifier Model. \n",
+    "\n",
+    "The model predicts whether an individual will default on their loan.\n",
+    "\n",
+    "We now want to kick off RIME Stress Tests, in a compliance setting, that will help us determine if the model is biased against protected attributes. In order to do this, we will upload this pre-trained model, the reference dataset the model was trained on, and the evaluation dataset the model was evaluated on to an S3 bucket that can be accessed by RIME."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "U1mcyn9JwdWQ",
+    "outputId": "59b08804-3542-43f5-f5ba-a89078951e78",
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "upload_path = \"ri_public_examples_lending\"\n",
+    "\n",
+    "model_s3_dir = client.upload_directory(\n",
+    "    Path('lending/models'), upload_path=upload_path\n",
+    ")\n",
+    "model_s3_path = model_s3_dir + \"/model.py\"\n",
+    "\n",
+    "ref_s3_path = client.upload_file(\n",
+    "    Path('lending/data/ref.csv'), upload_path=upload_path\n",
+    ")\n",
+    "eval_s3_path = client.upload_file(\n",
+    "    Path('lending/data/eval.csv'), upload_path=upload_path\n",
+    ")\n",
+    "\n",
+    "ref_preds_s3_path = client.upload_file(\n",
+    "    Path(\"lending/data/ref_preds.csv\"), upload_path=upload_path\n",
+    ")\n",
+    "eval_preds_s3_path = client.upload_file(\n",
+    "    Path(\"lending/data/eval_preds.csv\"), upload_path=upload_path\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Once the data and model are uploaded to S3, we can register them to RIME. In this bias and fairness setting, we require some additional information when registering datasets. Within the `data_params` parameter in the registering function, we include the protected features present in the data such that we can run our bias and fairness tests on those features. Once the datasets and models are registered, we can refer to these resources using their RIME-generated ID's."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from datetime import datetime\n",
+    "\n",
+    "dt = str(datetime.now())\n",
+    "\n",
+    "# Note: models and datasets need to have unique names.\n",
+    "model_id = project.register_model_from_path(f\"model_{dt}\", model_s3_path, agent_id=AGENT_ID)\n",
+    "\n",
+    "ref_dataset_id = project.register_dataset_from_file(f\"ref_dataset_{dt}\",\n",
+    "                                                    ref_s3_path,\n",
+    "                                                    data_params={\"label_col\": \"loan_status\",\n",
+    "                                                                 \"protected_features\": [\"sex\", \"race\", \"addr_state\"]\n",
+    "                                                                },\n",
+    "                                                   agent_id=AGENT_ID)\n",
+    "eval_dataset_id = project.register_dataset_from_file(f\"eval_dataset_{dt}\",\n",
+    "                                                     eval_s3_path,\n",
+    "                                                     data_params={\"label_col\": \"loan_status\",\n",
+    "                                                                  \"protected_features\": [\"sex\", \"race\", \"addr_state\"]\n",
+    "                                                                 },\n",
+    "                                                    agent_id=AGENT_ID)\n",
+    "ref_pred_id = project.register_predictions_from_file(ref_dataset_id, model_id, ref_preds_s3_path, agent_id=AGENT_ID)\n",
+    "\n",
+    "eval_pred_id = project.register_predictions_from_file(eval_dataset_id, model_id, eval_preds_s3_path, agent_id=AGENT_ID)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "yCasNMsy0Avt",
+    "pycharm": {
+     "name": "#%% md\n"
+    },
+    "tags": []
+   },
+   "source": [
+    "## **Running a Stress Test with Bias and Fairness**\n",
+    "\n",
+    "AI Stress Tests allow you to test your data and model before deployment. They are a comprehensive suite of hundreds of tests that automatically identify implicit assumptions and weaknesses of pre-production models. Each stress test is run on a single model and its associated reference and evaluation datasets. \n",
+    "\n",
+    "To run Stress Tests with the Bias & Fairness mode, there are two main changes to make. The first has been done already, namely specifying a set of `protected_features` in the `data_param` parameters of both datasets. The protected features are the specific features that you want Stress Tests to run over in order to test your model for signs of bias. Additionally, you will want to specify the Bias and Fairness Category in stress test config. This category does not run by default so specifying as such is necessary:\n",
+    "\n",
+    "```python\n",
+    "stress_test_config = {\n",
+    "        # rest of configuration ...\n",
+    "        \"categories\": [\"TEST_CATEGORY_TYPE_BIAS_AND_FAIRNESS\"]\n",
+    "}\n",
+    "```\n",
+    "\n",
+    "Note how the \"categories\" field contains \"Bias and Fairness\", along with other categories to test Security and Operational Risk.\n",
+    "\n",
+    "\n",
+    "Below is a sample configuration of how to setup and run a RIME Stress Test."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "MA-mVn3pzVA1",
+    "outputId": "c75f28b8-93a7-44e8-d451-1fcec26f7ff6",
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "stress_test_config = {\n",
+    "    \"data_info\": {\n",
+    "        \"ref_dataset_id\": ref_dataset_id,\n",
+    "        \"eval_dataset_id\": eval_dataset_id\n",
+    "    },\n",
+    "    \"model_id\": model_id,\n",
+    "    \"run_name\": \"Loan Default Prediction - Lending Club\",\n",
+    "    \"categories\": [\n",
+    "            \"TEST_CATEGORY_TYPE_ADVERSARIAL\",\n",
+    "            \"TEST_CATEGORY_TYPE_SUBSET_PERFORMANCE\",\n",
+    "            \"TEST_CATEGORY_TYPE_TRANSFORMATIONS\",\n",
+    "            \"TEST_CATEGORY_TYPE_BIAS_AND_FAIRNESS\"]\n",
+    "}\n",
+    "stress_job = client.start_stress_test(test_run_config=stress_test_config, project_id=project.project_id, agent_id=AGENT_ID)\n",
+    "stress_job.get_status(verbose=True, wait_until_finish=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "LFB5nVEaTtnB",
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "**Wait for a couple minutes and your results will appear in the UI.**"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "ovrKDoifIxIm",
+    "pycharm": {
+     "name": "#%% md\n"
+    },
+    "tags": []
+   },
+   "source": [
+    "## **Stress Test Results**\n",
+    "\n",
+    "Stress tests are grouped into categories that measure various aspects of model robustness (model behavior, distribution drift, abnormal input, transformations, adversarial attacks, bias and fairness). Suggestions to improve your model are aggregated on the category level as well. Tests are ranked by default by a shared severity metric. Clicking on an individual test surfaces more detailed information. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "h2jQYUDmknsU",
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "![img_3](https://drive.google.com/uc?id=1dYI1YLTZqOMcuk_KSRfJOavdS_26CKC3)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "Similar to running RIME Stress Tests in the default setting, we surface an overall distribution of test severities, model metrics, as well as key insights to the right. This test suite comprises a selection of Bias and Fairness tests over any protected features, Attack tests over all features,\n",
+    "and Abnormal Inputs tests over all features. These tests align with financial regulatory standards. Lets take a closer look at the Demographic Parity test:"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "h2jQYUDmknsU",
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "![img_4](https://drive.google.com/uc?id=1sBlvaUHu_Gwut_hmFN0tR_WJmcbpfTLZ)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "This test is commonly known as the demographic parity or statistical parity test in fairness literature. This test checks whether the model performs equally well across a given subset of rows as it does across the whole dataset. The key detail displays the performance difference between the lowest performing subset and the overall population. The test first splits the dataset into various subsets depending on the quantiles of a given feature column. If the feature is categorical, the data is split based on the feature values. We then test whether the Positive Prediction Rate of model predictions within a specific subset is significantly different than the model prediction Positive Prediction Rate over the entire 'population'.\n",
+    "\n",
+    "We can see that the model fails the demographic parity test for two of the three protected features that we configured."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 279
+    },
+    "id": "h2iYOcGiI16-",
+    "outputId": "2f6c190f-9081-4b65-f29b-8743879b1de6",
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "test_run = stress_job.get_test_run()\n",
+    "test_run"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "test_case_result = test_run.get_result_df()\n",
+    "test_case_result.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "XGivw_Weookf",
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "### **Programmatically Querying the Results**"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "HB4A2GouWysL",
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "RIME not only provides you with an intuitive UI to visualize and explore these results, but also allows you to programmatically query these results. This allows customers to integrate with their MLOps pipeline, log results to experiment management tools like MLFlow, bring automated decision making to their ML practicies, or store these results for future references. \n",
+    "\n",
+    "Run the below cell to programmatically query the results. The results are outputed as a pandas dataframe."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "fTWLakM8VQj6",
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "**Access results at the a test run overview level**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "dgawCIZWLFST",
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "test_run_result = test_run.get_result_df()\n",
+    "test_run_result.to_csv(\"Lending_Test_Run_Results.csv\")\n",
+    "test_run_result"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "tUUcNh7XVUPl",
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "**Access detailed test results at each individual test cases level.**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "u2qh2linVIt9",
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "test_case_result = test_run.get_test_cases_df()\n",
+    "test_case_result.to_csv(\"Lending_Test_Case_Results.csv\")\n",
+    "test_case_result.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "ovrKDoifIxIm",
+    "pycharm": {
+     "name": "#%% md\n"
+    },
+    "tags": []
+   },
+   "source": [
+    "## **Deploy to Production and set up AI Continuous Testing**\n",
+    "\n",
+    "Once you have identified the best stress test run, you can deploy continuous testing for the associated model. Continuous Testing operates on both a datapoint and batch level. It automatically protects your model in real-time from “bad” incoming data and also alerts on statistically significant distributional drift. \n",
+    "\n",
+    "In this scenario, the data scientist is short on time and decided to deploy the existing model to production. The data scientist also sets up Continuous Testing to monitor the model. Continuous Testing is automatically configured based on the failures identified by AI Stress testing to protect the tested model in Production."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 383
+    },
+    "id": "tt3uZvDtAbov",
+    "outputId": "277b3104-942b-4a62-fa82-21c248ef6422",
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "from datetime import timedelta\n",
+    "\n",
+    "# Set up Continuous Testing using previously registered model and dataset IDs.\n",
+    "ct = project.create_ct(model_id, ref_dataset_id, timedelta(days=1))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "a0Lw2YBXBkb4",
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "## **Uploading a Batch of Production Data & Model Predictions to Continuous Testing**\n",
+    "\n",
+    "The lending model has been in production for 30 days. Production data and model predictions have been collected and stored for the past 30 days. Now, we will use Continuous Testing to track how the model performed across the last 30 days."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "g7McYwfDUztC",
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "**Upload an Incremental Batch of Data**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 383
+    },
+    "id": "tt3uZvDtAbov",
+    "outputId": "277b3104-942b-4a62-fa82-21c248ef6422",
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "prod_s3_path = client.upload_file(\n",
+    "    Path('lending/data/incremental.csv'), \n",
+    "    upload_path=upload_path\n",
+    ")\n",
+    "prod_dataset_id = project.register_dataset_from_file(\n",
+    "    f\"prod_dataset_{dt}\", \n",
+    "    prod_s3_path, \n",
+    "    data_params={\"label_col\": \"loan_status\", \n",
+    "                 \"protected_features\": [\"sex\", \"race\", \"addr_state\"],\n",
+    "                 \"timestamp_col\": \"timestamp\"},\n",
+    ")\n",
+    "prod_preds_s3_path = client.upload_file(\n",
+    "    Path('lending/data/incremental_preds.csv'), \n",
+    "    upload_path=upload_path\n",
+    ")\n",
+    "project.register_predictions_from_file(\n",
+    "    prod_dataset_id, model_id, prod_preds_s3_path\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To run the Bias and Fairness category in Continuous Testing, you will want to specify the Bias and Fairness Category as a continuous test category. This category does not run by default so specifying along with other categories as such is necessary:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "project.update_continuous_test_categories([\"TEST_CATEGORY_TYPE_MODEL_PERFORMANCE\",\n",
+    "                                           \"TEST_CATEGORY_TYPE_SUBSET_PERFORMANCE_DEGRADATION\",\n",
+    "                                           \"TEST_CATEGORY_TYPE_ABNORMAL_INPUTS\",\n",
+    "                                           \"TEST_CATEGORY_TYPE_DRIFT\",\n",
+    "                                           \"TEST_CATEGORY_TYPE_BIAS_AND_FAIRNESS\"\n",
+    "                                          ])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "e-ooaBT-U4yr",
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "**Run Continuous Testing over Batch of Data**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 383
+    },
+    "id": "tt3uZvDtAbov",
+    "outputId": "277b3104-942b-4a62-fa82-21c248ef6422",
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "ct_job = ct.start_continuous_test(prod_dataset_id, agent_id=AGENT_ID)\n",
+    "ct_job.get_status(verbose=True, wait_until_finish=True)\n",
+    "ct"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "ifxKz_p6Uc63",
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "**Wait for a couple minutes and your results will appear in the UI.**"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "vmpxUnaLMn-u",
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "\n",
+    "## **Continuous Testing Overview**\n",
+    "\n",
+    "The page is the mission control for your model’s production deployment health. In it, you can see the status of continuous test runs, and see their metrics changes over time.  \n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "![img_5](https://drive.google.com/uc?id=1uT3q4pakoQSPhRf9HfxS5tyL16c3dDpx)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "MzMea8BUFOT1",
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "## **Continuous Test Results**\n",
+    "\n",
+    "The Continuous Tests operate at the batch level and provide a mechanism to monitor the health of ML deployments in production. They allow the user to understand when errors begin to occur and surface the underlying drivers of such errors. \n",
+    "\n",
+    "You can explore the results in the UI by running the below cell and redirecting to the generated link.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "Qndn2zUMLhJo",
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "ct"
+   ]
+  }
+ ],
+ "metadata": {
+  "colab": {
+   "collapsed_sections": [],
+   "name": "RIME_Finance_Compliance_Walkthrough_Lending.ipynb",
+   "provenance": []
+  },
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/notebooks/demo_notebooks/RIME_NLP_REST_WALKTHROUGH.ipynb
+++ b/notebooks/demo_notebooks/RIME_NLP_REST_WALKTHROUGH.ipynb
@@ -1,0 +1,383 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "96da536c",
+   "metadata": {},
+   "source": [
+    "# **RI NLP Walkthrough using REST API**\n",
+    "\n",
+    "> ▶️ **Try this in Colab!** Run the [RI NLP REST Walkthrough in Google Colab](https://colab.research.google.com/github/RobustIntelligence/docs/blob/main/notebooks/demo_notebooks/RIME_NLP_REST_WALKTHROUGH.ipynb). \n",
+    "\n",
+    "In this Notebook Walkthrough, we will walkthrough one of RIME's core products using our REST API - AI Stress Testing.\n",
+    "\n",
+    "AI Stress Testing is used in the model development stage. Using AI Stress Testing you can test the developed model. RIME goes beyond simply optimizing for basic model performance like accuracy and automatically discovers the model's weaknesses."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1d0121cd-fdc5-4d48-a667-67057c9572f6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "import requests\n",
+    "import time\n",
+    "import uuid\n",
+    "from datetime import datetime\n",
+    "from typing import List, Optional, Tuple"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c88f2d41",
+   "metadata": {},
+   "source": [
+    "## **Establish the RIME Client.**\n",
+    "To get started, provide the API credentials and the base domain/address of the RIME service. You can generate and copy an API token from the API Access Tokens Page under Workspace settings. For the domain/address of the RIME service, contact your admin."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8a0eadc9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "API_TOKEN = \"\" # Paste API_KEY\n",
+    "headers = {\"rime-api-key\": API_TOKEN}\n",
+    "\n",
+    "CLUSTER_URL = \"\" # PASTE DOMAIN OF RIME SERVICE (eg: rime.example.rbst.io)\n",
+    "API_URL = f\"https://{CLUSTER_URL}\"\n",
+    "\n",
+    "AGENT_ID = '' # PASTE AGENT_ID IF USING AN AGENT THAT IS NOT THE DEFAULT"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e197934c",
+   "metadata": {},
+   "source": [
+    "## **Create a New Project.**\n",
+    "You can create Projects in RIME to organize your Test Runs. Each Project represents a workspace for a given machine learning task. It can contain multiple candidate models, but should only contain one promoted production model."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4c6d48aa",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create a Project for the Natural Language Inference model task.\n",
+    "req = {\n",
+    "    \"name\": \"NLP Example\",\n",
+    "    \"description\": \"Example stress test on NLP data.\",\n",
+    "    \"model_task\": \"MODEL_TASK_NATURAL_LANGUAGE_INFERENCE\"\n",
+    "}\n",
+    "api_endpoint = f\"{API_URL}/v1/projects\"\n",
+    "res = requests.post(\n",
+    "    api_endpoint,\n",
+    "    json=req,\n",
+    "    headers=headers,\n",
+    ")\n",
+    "assert res.status_code == 200\n",
+    "# Get the Project ID from the response. This will be needed to start a Stress Test.\n",
+    "project_id = res.json()[\"project\"][\"id\"]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "50d85b23",
+   "metadata": {},
+   "source": [
+    "## **Optional: Create Job Tracker.**\n",
+    "Once a Stress Test request or Managed Image request has been sent, we have to wait until the Job completes before checking for results. The following helper functions track the status of a job by blocking until the Job has status \"Succeeded\"."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dc76dcc9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Helper function for displaying Job Status.\n",
+    "def _add_padding(string: str) -> str:\n",
+    "    max_str_len = len(\"JOB_STATUS_REQUESTED\")\n",
+    "    padding_len = max(max_str_len - len(string), 0)\n",
+    "    return string + \" \" * padding_len\n",
+    "\n",
+    "# Helper function for periodically querying for Job status.\n",
+    "def track_job(job_id):\n",
+    "    time.sleep(1)\n",
+    "    api_endpoint = f\"{API_URL}/v1/jobs/{job_id}\"\n",
+    "    res = requests.get(api_endpoint, headers=headers)\n",
+    "    job_status = res.json()[\"job\"][\"status\"]\n",
+    "\n",
+    "    i = 0\n",
+    "    while job_status != \"JOB_STATUS_SUCCEEDED\":\n",
+    "        res = requests.get(api_endpoint, headers=headers)\n",
+    "        res_json = res.json()\n",
+    "        job_status = res.json()[\"job\"][\"status\"]\n",
+    "        i += 1\n",
+    "        print(f\"Poll count: {i}.\\tJob status: {_add_padding(job_status)}\", end=\"\\r\")\n",
+    "        if job_status == \"JOB_STATUS_FAILED\":\n",
+    "            logs_url = res_json[\"job\"][\"archivedJobLogs\"][\"url\"][\"url\"]\n",
+    "            raise ValueError(f\"Test run failed. Job logs available at {logs_url}.\")\n",
+    "        time.sleep(10)\n",
+    "\n",
+    "    return res_json"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a2a16869",
+   "metadata": {},
+   "source": [
+    "## **Create Managed Image.**\n",
+    "In order to run a Stress Test against a huggingface model, we have to create a Managed Image with the model's pip requirements pre-installed. The following snippet checks if a huggingface Managed Image exists, and if not, creates one."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "17940fb0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "managed_image_name = \"huggingface_image\"\n",
+    "\n",
+    "api_endpoint = f\"{API_URL}/images/{managed_image_name}\"\n",
+    "res = requests.get(api_endpoint, headers=headers)\n",
+    "managed_image_exists = (res.status_code == 200)\n",
+    "\n",
+    "if not managed_image_exists:\n",
+    "    req = {\n",
+    "        \"name\": managed_image_name,\n",
+    "        \"pip_requirements\": [\n",
+    "            {\"name\": \"transformers\"},\n",
+    "            {\"name\": \"datasets\"},\n",
+    "        ],\n",
+    "    }\n",
+    "    api_endpoint = f\"{API_URL}/images\"\n",
+    "    res = requests.post(api_endpoint, headers=headers)\n",
+    "    job_id = res.json()[\"job\"][\"jobId\"]\n",
+    "    \n",
+    "    track_job(job_id)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "18b239ec",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# These are the URIs of the model that we want to Stress Test, and an associated dataset.\n",
+    "DATASET_URI = \"rungalileo/snli\"\n",
+    "MODEL_URI = \"cross-encoder/nli-MiniLM2-L6-H768\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "08208cb6",
+   "metadata": {},
+   "source": [
+    "## **Register Dataset**\n",
+    "Now that we have the huggingface model URIs, we can register them and the dataset to RIME. Once they're registed, we can refer to these resources using their RIME-generated ID's."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b70777af",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dt = str(datetime.now())\n",
+    "\n",
+    "# Register the huggingface dataset.\n",
+    "def register_dataset(dataset_uri, split_name):\n",
+    "    api_endpoint = f\"{API_URL}/v1/registry/{project_id['uuid']}/dataset\"\n",
+    "    req = {\n",
+    "        # Note: models and datasets need to have unique names.\n",
+    "        \"name\": f\"{dataset_uri}_{split_name}_{dt}\",\n",
+    "        \"data_info\": {\n",
+    "            \"connection_info\": {\n",
+    "                \"hugging_face\": {\n",
+    "                    \"dataset_uri\": dataset_uri,\n",
+    "                    \"split_name\": split_name,\n",
+    "                    # TODO: remove line below\n",
+    "                    \"loading_params_json\": json.dumps({}),\n",
+    "                },\n",
+    "            },\n",
+    "            \"data_params\": {\n",
+    "                \"label_col\": \"label\",\n",
+    "                \"text_features\": [\"premise\", \"hypothesis\"],\n",
+    "                \"class_names\": [\"Contradiction\", \"Neutral\", \"Entailment\"],\n",
+    "            },\n",
+    "        },\n",
+    "    }\n",
+    "    if AGENT_ID:\n",
+    "        req[\"agent_id\"] = {\"uuid\": AGENT_ID}\n",
+    "    res = requests.post(api_endpoint, json=req, headers=headers)\n",
+    "    return res.json()[\"datasetId\"]\n",
+    "\n",
+    "\n",
+    "ref_data_id = register_dataset(DATASET_URI, \"train\")\n",
+    "eval_data_id = register_dataset(DATASET_URI, \"test\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b983b1b5",
+   "metadata": {},
+   "source": [
+    "## **Register Model**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "751988dd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "api_endpoint = f\"{API_URL}/v1/registry/{project_id['uuid']}/model\"\n",
+    "req = {\n",
+    "    # Note: models and datasets need to have unique names.\n",
+    "    \"name\": f\"{MODEL_URI}_{dt}\",\n",
+    "    \"model_info\": {\n",
+    "        \"hugging_face\": {\n",
+    "            \"model_uri\": MODEL_URI,\n",
+    "        },\n",
+    "    },\n",
+    "}\n",
+    "if AGENT_ID:\n",
+    "    req[\"agent_id\"] = {\"uuid\": AGENT_ID}\n",
+    "res = requests.post(api_endpoint, json=req, headers=headers)\n",
+    "model_id = res.json()[\"modelId\"]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fb01bcea",
+   "metadata": {},
+   "source": [
+    "## **Create Test Run Config**\n",
+    "Below is a sample configuration of how to setup and run a RIME Stress Test. The configuration includes important information, such as the IDs of the model, reference dataset, evaluation dataset and the name of a Managed Image to use (optional)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1b5be11f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "config = {\n",
+    "    \"run_name\": \"NLP Stress Test\",\n",
+    "    \"model_id\": model_id,\n",
+    "    \"data_info\": {\n",
+    "        \"ref_dataset_id\": ref_data_id,\n",
+    "        \"eval_dataset_id\": eval_data_id,\n",
+    "    },\n",
+    "    \"run_time_info\": {\n",
+    "        \"custom_image\": {\n",
+    "            \"managed_image_name\": managed_image_name,\n",
+    "        },\n",
+    "    },\n",
+    "    \"test_suite_config\": {\n",
+    "        \"global_exclude_columns\": [\"id\"]\n",
+    "    },\n",
+    "}\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ffcc1f67",
+   "metadata": {},
+   "source": [
+    "## **Run Stress Test**\n",
+    "With a completed Test Run Configuration, we can now start a Stress Test and track its progress until the tests complete."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ccab53cd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "req = {\"test_run_config\": config}\n",
+    "if AGENT_ID:\n",
+    "    req[\"agent_id\"] = {\"uuid\": AGENT_ID}\n",
+    "api_endpoint = f\"{API_URL}/v1/stress-tests/{project_id['uuid']}\"\n",
+    "res = requests.post(api_endpoint, json=req, headers=headers)\n",
+    "job_id = res.json()[\"job\"][\"jobId\"]\n",
+    "\n",
+    "# Track Stress Test Job Progress.\n",
+    "res_json = track_job(job_id)\n",
+    "\n",
+    "# Once a Stress Test Job has completed, get the Test Run ID to access results.\n",
+    "test_run_id = res_json[\"job\"][\"jobData\"][\"stress\"][\"testRunId\"]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8d8dda5b",
+   "metadata": {},
+   "source": [
+    "## **Get Test Run Results.**\n",
+    "Once a Test Run completes, we can access the results of the Stress Test using the Test Run ID."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6198df23",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Print information about a completed Test Run.\n",
+    "api_endpoint = f\"{API_URL}/v1/test-runs/{test_run_id}\"\n",
+    "res = requests.get(api_endpoint, headers=headers)\n",
+    "print(res.json()[\"testRun\"])\n",
+    "\n",
+    "# List individual Test Cases from the Test Run.\n",
+    "api_endpoint = f\"{API_URL}/v1/test-cases\"\n",
+    "payload = {\"listTestCasesQuery.testRunId\": test_run_id}\n",
+    "res = requests.get(api_endpoint, headers=headers, params=payload)\n",
+    "print(res.json()[\"testCases\"])\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.3"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "f741bca4f9b8ddfd670f2fa9f61c4f441cd8de906862a8d74a2d07bd8aaef458"
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/demo_notebooks/RIME_NLP_Walkthrough.ipynb
+++ b/notebooks/demo_notebooks/RIME_NLP_Walkthrough.ipynb
@@ -1,0 +1,873 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "22441406",
+   "metadata": {
+    "id": "22441406"
+   },
+   "source": [
+    "# **RI NLP Multiclass Classification Walkthrough**"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "139eb33d",
+   "metadata": {
+    "id": "139eb33d"
+   },
+   "source": [
+    "\n",
+    "> ▶️ **Try this in Colab!** Run the [RI NLP Multiclass Classification Walkthrough in Google Colab](https://colab.research.google.com/github/RobustIntelligence/docs/blob/main/notebooks/demo_notebooks/RIME_NLP_Walkthrough.ipynb). \n",
+    "\n",
+    "You are a data scientist working to maintain a large research library. The data science team has been tasked with implementing a research paper topic classification model and monitoring how that model performs over time. The performance of this model directly impacts the profits of the company. To ensure the data science team develops the best model and the performance of this model doesn't degrade over time, the VP of Data Science purchases the RIME platform.\n",
+    "\n",
+    "In this Notebook Walkthrough, we will walkthrough 2 of RIME's core products - **AI Stress Testing** and **AI Continuous Testing**.\n",
+    "\n",
+    "1. **AI Stress Testing** is used in the model development stage. Using AI Stress Testing you can test the developed model. RIME goes beyond simply optimizing for basic model performance like accuracy and automatically discovers the model's weaknesses.\n",
+    "2. **AI Continuous Testing** is used after the model is deployed in production. Using AI Continuous Testing, you can automate the monitoring, discovery and remediation of issues that occur post-deployment."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "55f7dbb3",
+   "metadata": {
+    "id": "55f7dbb3"
+   },
+   "source": [
+    "## **Install Dependencies, Import Libraries and Download Data**"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "77c29f18",
+   "metadata": {
+    "id": "77c29f18"
+   },
+   "source": [
+    "Run the cell below to install libraries to receive data, install our SDK, and load analysis libraries."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2dfa4cb5",
+   "metadata": {
+    "id": "2dfa4cb5"
+   },
+   "outputs": [],
+   "source": [
+    "!pip install rime-sdk &> /dev/null\n",
+    "\n",
+    "import pandas as pd\n",
+    "from pathlib import Path\n",
+    "from rime_sdk import Client"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "hLpEVK64Mmti",
+   "metadata": {
+    "id": "hLpEVK64Mmti"
+   },
+   "outputs": [],
+   "source": [
+    "!pip install https://github.com/RobustIntelligence/ri-public-examples/archive/master.zip\n",
+    "    \n",
+    "from ri_public_examples.download_files import download_files\n",
+    "\n",
+    "download_files('nlp/classification/arxiv-2.0', 'arxiv')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0ca803a7",
+   "metadata": {
+    "id": "0ca803a7"
+   },
+   "source": [
+    "## **Establish the RIME Client**"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "38e5f5a7",
+   "metadata": {
+    "id": "38e5f5a7"
+   },
+   "source": [
+    "To get started, provide the API credentials and the base domain/address of the RIME Cluster. You can generate and copy an API token from the API Access Tokens Page under Workspace settings. For the domain/address of the RIME Cluster, contact your admin."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "40334928",
+   "metadata": {},
+   "source": [
+    "![api.jpeg](https://www.dropbox.com/s/bpz7vb8j6a7zgwu/img_1_api.jpeg?dl=0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e29a5ce6",
+   "metadata": {
+    "id": "e29a5ce6"
+   },
+   "outputs": [],
+   "source": [
+    "API_TOKEN = '' # PASTE API_KEY \n",
+    "CLUSTER_URL = '' # PASTE DEDICATED DOMAIN OF RIME SERVICE (eg: rime.stable.rbst.io)\n",
+    "AGENT_ID = '' # PASTE AGENT_ID IF USING AN AGENT THAT IS NOT THE DEFAULT\n",
+    "client = Client(CLUSTER_URL, API_TOKEN)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bce4684d",
+   "metadata": {
+    "id": "bce4684d",
+    "tags": []
+   },
+   "source": [
+    "## **Create a New Project**"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5d26ed83",
+   "metadata": {
+    "id": "5d26ed83"
+   },
+   "source": [
+    "You can create projects in RIME to organize your test runs. Each project represents a workspace for a given machine learning task. It can contain multiple candidate models, but should only contain one promoted production model."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3b65dd7f",
+   "metadata": {
+    "id": "3b65dd7f"
+   },
+   "outputs": [],
+   "source": [
+    "description = (\n",
+    "    \"Run Stress Testing and Continuous Testing on a\"\n",
+    "    \" text classification model and dataset. Demonstration uses \"\n",
+    "    \" a dataset composed of ArXiv paper titles where the task is\"\n",
+    "    \" to predict the paper topic.\"\n",
+    ")\n",
+    "project = client.create_project(\n",
+    "    name='Text Classification Demo', \n",
+    "    description=description,\n",
+    "    model_task='MODEL_TASK_MULTICLASS_CLASSIFICATION'\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6cd5eb92",
+   "metadata": {
+    "id": "6cd5eb92"
+   },
+   "source": [
+    "**Go back to the UI to see the Arxiv Project**"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "86e144e4",
+   "metadata": {
+    "id": "86e144e4"
+   },
+   "source": [
+    "## **Uploading the Model + Datasets + Predictions**"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "badd1201",
+   "metadata": {
+    "id": "badd1201"
+   },
+   "source": [
+    "For this demo, we are going to use the prediction logs of a text classification model for arxiv, a popular research database.\n",
+    "\n",
+    "The model classifies the research paper into a number of different categories such as - \n",
+    "\n",
+    "1. Black Hole\n",
+    "2. Neutron Star\n",
+    "3. Dark Matter\n",
+    "\n",
+    "We now want to kick off RIME Stress Tests that will help us evaluate the model in further depth beyond basic performance metrics like accuracy, precision, recall. In order to do this, we will upload this pre-trained model, the reference dataset the model was trained on, and the evaluation dataset the model was evaluated on to an S3 bucket that can be accessed by RIME. Futhermore, we'll need to register them with RIME."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "926b29f2",
+   "metadata": {
+    "id": "926b29f2"
+   },
+   "outputs": [],
+   "source": [
+    "upload_path = \"ri_public_examples_arxiv\"\n",
+    "ref_s3_path = client.upload_file(\n",
+    "    Path('arxiv/data/train.json.gz'), upload_path=upload_path\n",
+    ")\n",
+    "eval_s3_path = client.upload_file(\n",
+    "    Path('arxiv/data/val_0_with_label.json.gz'), upload_path=upload_path\n",
+    ")\n",
+    "ref_preds_s3_path = client.upload_file(\n",
+    "    Path(\"arxiv/data/preds.train.jsonl.gz\"), upload_path=upload_path\n",
+    ")\n",
+    "eval_preds_s3_path = client.upload_file(\n",
+    "    Path(\"arxiv/data/preds.val_0.jsonl.gz\"), upload_path=upload_path\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "220524de-f955-476c-ac12-e9f6b914b187",
+   "metadata": {},
+   "source": [
+    "Once the data and model are uploaded to S3, we can register them to RIME. Once they're registered, we can refer to these resources using their RIME-generated ID's."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ac15ee52-b195-474d-883c-8bd28c9aea26",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from datetime import datetime\n",
+    "\n",
+    "dt = str(datetime.now())\n",
+    "\n",
+    "# Note: models and datasets need to have unique names.\n",
+    "model_id = project.register_model(\n",
+    "    f'model_{dt}',\n",
+    "    model_config={\"hugging_face\": {\"model_uri\": \"Wi/arxiv-distilbert-base-cased\"}},\n",
+    "    agent_id=AGENT_ID\n",
+    ")\n",
+    "data_params = {\n",
+    "    \"label_col\": \"label\",\n",
+    "    \"text_features\": [\n",
+    "        \"text\"\n",
+    "    ],\n",
+    "    \"timestamp_col\": \"timestamp\"\n",
+    "}\n",
+    "ref_dataset_id = project.register_dataset_from_file(\n",
+    "    f\"ref_dataset_{dt}\", ref_s3_path, data_params=data_params, agent_id=AGENT_ID\n",
+    ")\n",
+    "eval_dataset_id = project.register_dataset_from_file(\n",
+    "    f\"eval_dataset_{dt}\", eval_s3_path, data_params=data_params, agent_id=AGENT_ID\n",
+    ")\n",
+    "project.register_predictions_from_file(\n",
+    "    ref_dataset_id, model_id, ref_preds_s3_path, agent_id=AGENT_ID\n",
+    ")\n",
+    "project.register_predictions_from_file(\n",
+    "    eval_dataset_id, model_id, eval_preds_s3_path, agent_id=AGENT_ID\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a7ff3270",
+   "metadata": {
+    "id": "a7ff3270"
+   },
+   "source": [
+    "## **Running a Stress Test**"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3cd67e3f",
+   "metadata": {
+    "id": "3cd67e3f"
+   },
+   "source": [
+    "AI Stress Tests allow you to test your data and model before deployment. \n",
+    "They are a comprehensive suite of hundreds of tests that automatically identify implicit assumptions and weaknesses of pre-production models. Each stress test is run on a single model and its associated reference and evaluation datasets."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8n-_-QpbbUOD",
+   "metadata": {
+    "id": "8n-_-QpbbUOD"
+   },
+   "source": [
+    "Below is a sample configuration of how to setup and run a RIME Stress Test for NLP."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "35d40591",
+   "metadata": {
+    "id": "35d40591"
+   },
+   "outputs": [],
+   "source": [
+    "stress_test_config = {\n",
+    "    \"run_name\": \"ArXiv Topic Classification\",\n",
+    "    \"data_info\": {\n",
+    "        \"ref_dataset_id\": ref_dataset_id,\n",
+    "        \"eval_dataset_id\": eval_dataset_id,\n",
+    "    },\n",
+    "    \"model_id\": model_id,\n",
+    "    \"run_time_info\": {\n",
+    "        \"random_seed\": 42,\n",
+    "    },\n",
+    "    \"categories\": [\n",
+    "        \"TEST_CATEGORY_TYPE_ADVERSARIAL\",\n",
+    "        \"TEST_CATEGORY_TYPE_SUBSET_PERFORMANCE\",\n",
+    "        \"TEST_CATEGORY_TYPE_TRANSFORMATIONS\",\n",
+    "        \"TEST_CATEGORY_TYPE_BIAS_AND_FAIRNESS\", # this category is off by default\n",
+    "    ]\n",
+    "}\n",
+    "stress_job = client.start_stress_test(\n",
+    "    test_run_config=stress_test_config,\n",
+    "    project_id=project.project_id,\n",
+    "    agent_id=AGENT_ID\n",
+    ")\n",
+    "stress_job.get_status(verbose=True, wait_until_finish=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ac71b930",
+   "metadata": {
+    "id": "ac71b930"
+   },
+   "source": [
+    "## **Stress Test Results**"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0e02c6cb",
+   "metadata": {
+    "id": "0e02c6cb"
+   },
+   "source": [
+    "Stress tests are grouped into categories that measure various aspects of model robustness (subset performance, distribution drift, abnormal input). Suggestions to improve your model are aggregated on the category level as well. Tests are ranked by default by a shared severity metric. Clicking on an individual test surfaces more detailed information.\n",
+    "\n",
+    "You can view the detailed results in the UI by running the below cell and redirecting to the generated link. This page shows granular results for a given AI Stress Test run."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "53454038",
+   "metadata": {
+    "id": "53454038"
+   },
+   "outputs": [],
+   "source": [
+    "test_run = stress_job.get_test_run()\n",
+    "test_run"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1516b6d3",
+   "metadata": {
+    "id": "1516b6d3"
+   },
+   "source": [
+    "### Analyzing the Results"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4f6d7963",
+   "metadata": {
+    "id": "4f6d7963"
+   },
+   "source": [
+    "Below you can see a snapshot of the results and the different tests that we run. Some of these tests such as the Subset Performance Tests analyze how your model performs on different groups in the data, while others such as Transformations Tests analyze how your model reacts to augmented and malicious text data."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9b503ab6",
+   "metadata": {},
+   "source": [
+    "![stress.png](https://drive.google.com/uc?id=1TZMaQ9vcHvObNqLy86bdXozI_aFPk874)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "AZHS7eaFDlYV",
+   "metadata": {
+    "id": "AZHS7eaFDlYV"
+   },
+   "source": [
+    "#### Subset Performance Tests"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d84b3aa0",
+   "metadata": {
+    "id": "d84b3aa0"
+   },
+   "source": [
+    "Here are the results of the Subset Performance tests. These tests can be thought as more detailed performance tests that identify subsets of underperformance. These tests help ensure that the model works equally well across different groups."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "12941dd1",
+   "metadata": {},
+   "source": [
+    "![subset.png](https://drive.google.com/uc?id=1m-YaOEv7JJmxGRnaGUUZ-wT7Sy6D4k2F)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3d984daa",
+   "metadata": {
+    "id": "3d984daa"
+   },
+   "source": [
+    "Below we are exploring the \"Subset Macro Precision\" test cases for the text metadata feature \"AverageTokenLength\". We can see that even though the model has a Macro Precision of 0.53, it performs poorly on certain subsets, especially those with lower average token lengths."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "caad7230",
+   "metadata": {},
+   "source": [
+    "![precision.png](https://drive.google.com/uc?id=1tSBMtZy-6qEnsh2xV6u98Zr3YBqdmmCV)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "L-TXi6pnDsV8",
+   "metadata": {
+    "id": "L-TXi6pnDsV8"
+   },
+   "source": [
+    "#### Transformation Tests"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7tIKl3xrDyfe",
+   "metadata": {
+    "id": "7tIKl3xrDyfe"
+   },
+   "source": [
+    "Here are the results of the Transformation tests. These tests can be thought as ways to test your models response to augmented text data. They help to make sure that your model is invariant to such changes in your data."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "08cd198e",
+   "metadata": {},
+   "source": [
+    "![transform.png](https://drive.google.com/uc?id=1DIwzsn7lxm6DzkeYavLQVV1dmvDLdBUi)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ydb-roGBEa77",
+   "metadata": {
+    "id": "ydb-roGBEa77"
+   },
+   "source": [
+    "Below we are exploring a transformation test that changes the original text to upper-case text. We see that this transformation causes the original class's predicted score to change by 0.70. As a result, the model predicts an entirely new class for the text and misclassifies it."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f1697117",
+   "metadata": {},
+   "source": [
+    "![replacement.png](https://drive.google.com/uc?id=1EwNbC9RPy2lhvUDiI2uswN5kKmkGn3Eo)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "00a24782",
+   "metadata": {
+    "id": "00a24782"
+   },
+   "source": [
+    "### Programmatically Querying the Results"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4bdb3ec3",
+   "metadata": {
+    "id": "4bdb3ec3"
+   },
+   "source": [
+    "RIME not only provides you with an intuitive UI to visualize and explore these results, but also allows you to programmatically query these results. This allows customers to integrate with their MLOps pipeline, log results to experiment management tools like MLFlow, bring automated decision making to their ML practices, or store these results for future references.\n",
+    "\n",
+    "Run the below cell to programmatically query the results. The results are outputted as a pandas dataframe."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9c3b82d0",
+   "metadata": {
+    "id": "9c3b82d0"
+   },
+   "source": [
+    "**Access results at the a test run overview level**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3ada9b87",
+   "metadata": {
+    "id": "3ada9b87"
+   },
+   "outputs": [],
+   "source": [
+    "test_run_result = test_run.get_result_df()\n",
+    "test_run_result.to_csv(\"Arxiv_Test_Run_Results.csv\")\n",
+    "test_run_result"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2368f059",
+   "metadata": {
+    "id": "2368f059"
+   },
+   "source": [
+    "**Access detailed test results at each individual test cases level**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6c0791c5",
+   "metadata": {
+    "id": "6c0791c5"
+   },
+   "outputs": [],
+   "source": [
+    "test_case_result = test_run.get_test_cases_df()\n",
+    "test_case_result.to_csv(\"Arxiv_Test_Case_Results.csv\")\n",
+    "test_case_result"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "651b1a21",
+   "metadata": {},
+   "source": [
+    "**Access detailed test results for a given test batch**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "152b13ad",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "subset_macro_f1 = test_run.get_test_batch(\"subset_performance:subset_macro_f1\")\n",
+    "subset_macro_f1.get_test_cases_df()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1a787ecc",
+   "metadata": {
+    "id": "1a787ecc"
+   },
+   "source": [
+    "## **Deploy to Production and set up Continuous Testing**"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "776d9dee",
+   "metadata": {
+    "id": "776d9dee"
+   },
+   "source": [
+    "Once you have identified the best stress test run, you can deploy the associated model and set up Continuous Testing in order to automatically detect “bad” incoming data and statistically significant distributional drift. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "12780c88",
+   "metadata": {
+    "id": "12780c88"
+   },
+   "outputs": [],
+   "source": [
+    "from datetime import timedelta\n",
+    "\n",
+    "ct_instance = project.create_ct(model_id, ref_dataset_id, timedelta(days=1))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3486dfe2",
+   "metadata": {
+    "id": "3486dfe2"
+   },
+   "source": [
+    "## **Uploading a Batch of Production Data & Model Predictions to Continuous Testing**"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e45cf559",
+   "metadata": {
+    "id": "e45cf559"
+   },
+   "source": [
+    "The text classification model has been in production for the past week. Production data and model predictions have been collected and stored for the past week. Now, we will use Continuous Testing to track how the model performed across the last week."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c9731dc4-6019-4ac3-ad51-944d812d158d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dt = str(datetime.now())\n",
+    "data_params = {\n",
+    "    \"text_features\": [\n",
+    "        \"text\"\n",
+    "    ],\n",
+    "    \"timestamp_col\": \"timestamp\"\n",
+    "}\n",
+    "prod_s3_path = client.upload_file(\n",
+    "    Path('arxiv/data/val_1.json.gz'), \n",
+    "    upload_path=upload_path\n",
+    ")\n",
+    "prod_dataset_id = project.register_dataset_from_file(\n",
+    "    f\"prod_dataset_{dt}\", \n",
+    "    prod_s3_path, \n",
+    "    data_params=data_params,\n",
+    "    agent_id=AGENT_ID\n",
+    ")\n",
+    "prod_preds_s3_path = client.upload_file(\n",
+    "    Path('arxiv/data/preds.val_1.jsonl.gz'), \n",
+    "    upload_path=upload_path,\n",
+    ")\n",
+    "project.register_predictions_from_file(\n",
+    "    prod_dataset_id, model_id, prod_preds_s3_path, agent_id=AGENT_ID\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5e88c523",
+   "metadata": {
+    "id": "5e88c523"
+   },
+   "source": [
+    "**Get Continuous Testing**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3dc01dd3",
+   "metadata": {
+    "id": "3dc01dd3"
+   },
+   "outputs": [],
+   "source": [
+    "ct_instance = client.get_ct_for_project(project.project_id)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2905e5fe",
+   "metadata": {
+    "id": "2905e5fe"
+   },
+   "source": [
+    "**Run Continuous Testing over Batch of Data**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f7ee267b",
+   "metadata": {
+    "id": "f7ee267b"
+   },
+   "outputs": [],
+   "source": [
+    "ct_job = ct_instance.start_continuous_test(prod_dataset_id, agent_id=AGENT_ID)\n",
+    "ct_job.get_status(verbose=True, wait_until_finish=True)\n",
+    "ct_instance"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b3069139",
+   "metadata": {
+    "id": "b3069139"
+   },
+   "source": [
+    "**Wait for a couple minutes and your results will appear in the UI**"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "06ed0741-4bcd-4dd4-b001-58c68e4cdd0a",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "## **Querying Results from Continuous Testing**"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "75235c63-eb39-4bc8-9de4-1b439cd9f560",
+   "metadata": {},
+   "source": [
+    "After continuous testing has been set up and data has been uploaded for processing, the user can query the results throughout the entire uploaded history."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6b7721d7-4df3-455d-bd46-a045fc4b68ad",
+   "metadata": {},
+   "source": [
+    "**Obtain All Detection Events**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b3c16f43-c234-4b33-a2b4-cdedf82c7914",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "events = [d.to_dict() for m in ct_instance.list_monitors() for d in m.list_detected_events()]\n",
+    "events_df = pd.DataFrame(events).drop([\"id\", \"project_id\", \"firewall_id\", \"event_object_id\", \"description_html\", \"last_update_time\"], axis=1)\n",
+    "events_df.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "55a637f2-bfa3-47bc-a150-a378436ed52a",
+   "metadata": {
+    "id": "vmpxUnaLMn-u"
+   },
+   "source": [
+    "\n",
+    "## **CT Overview**\n",
+    "\n",
+    "The Overview page is the mission control for your model’s production deployment health. In it, you can see the status of continuous test runs and their metrics change over time.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d1e52c50-50f9-4e2d-884d-1beeeca1f978",
+   "metadata": {
+    "id": "AFuGGg8uNtC2"
+   },
+   "source": [
+    "![img_5](https://drive.google.com/uc?id=1bd17xeRw81iziUZJqxeFyVP9T-O1LljZ)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a496a836-48b1-4414-92a4-50dc5fa60d21",
+   "metadata": {
+    "id": "MzMea8BUFOT1"
+   },
+   "source": [
+    "## **CT Results**\n",
+    "\n",
+    "The Continuous Tests operate at the batch level and provide a mechanism to monitor the health of ML deployments in production. They allow the user to understand when errors begin to occur and surface the underlying drivers of such errors. \n",
+    "\n",
+    "You can explore the results in the UI by running the below cell and redirecting to the generated link.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c205fbda-e09e-4e2e-80e5-dac19ad41ec8",
+   "metadata": {
+    "id": "Qndn2zUMLhJo"
+   },
+   "outputs": [],
+   "source": [
+    "ct_instance"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "02564b07-2987-4dc0-b72d-e0334e7cae32",
+   "metadata": {
+    "id": "719bad4b"
+   },
+   "source": [
+    "### **Analyzing CT Results**\n",
+    "\n",
+    "**Failing Rows Rate Increases For a Time Period** - In the below image, we can see that the failing rows rate has increased in the middle of the week, from when the model was first deployed."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "13117af9-11a7-4b5e-9d01-11e2eaf91504",
+   "metadata": {
+    "id": "jwelJ7gcLqgV"
+   },
+   "source": [
+    "![img_6](https://drive.google.com/uc?id=1ebqpuNvMwp9eMCJ7PX9FWf_dpj3FAtFn)"
+   ]
+  }
+ ],
+ "metadata": {
+  "colab": {
+   "collapsed_sections": [
+    "070f5702",
+    "d3ab0c6b"
+   ],
+   "name": "RIME_NLP_Walkthrough.ipynb",
+   "provenance": []
+  },
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.17"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "adacf6347835c0276f230fbe40e5e6a5cd451b7abae6a82fbc9025be2b203b7d"
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/demo_notebooks/RIME_Ranking_Walkthrough.ipynb
+++ b/notebooks/demo_notebooks/RIME_Ranking_Walkthrough.ipynb
@@ -1,0 +1,609 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "wDInylzdEcsB",
+    "tags": []
+   },
+   "source": [
+    "# **RI Movie Ratings Ranking Data Walkthrough** 🎥\n",
+    "\n",
+    "> ▶️ **Try this in Colab!** Run the [RI Movie Ratings Ranking Data Walkthrough in Google Colab](https://colab.research.google.com/github/RobustIntelligence/docs/blob/main/notebooks/demo_notebooks/RIME_Ranking_Walkthrough.ipynb). \n",
+    "\n",
+    "In this walkthrough, you are a data scientist tasked with training a recommendation system to predict whether or not a given user will upvote a movie. From experience, the team has found that the upstream data pipelines can be brittle, and want to use RIME to:\n",
+    "\n",
+    "1) Proactively test how vulnerable the model is to data failures during stress testing.\n",
+    "\n",
+    "2) To continuously monitor and track broken inputs in production."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "iU8NMTH-WPz6"
+   },
+   "source": [
+    "## **Install Dependencies, Import Libraries and Download Data**\n",
+    "Run the cell below to install libraries to receive data, install our SDK, and load analysis libraries."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "Mcq3snDVExtE"
+   },
+   "outputs": [],
+   "source": [
+    "!pip install rime-sdk &> /dev/null\n",
+    "\n",
+    "import pandas as pd\n",
+    "from pathlib import Path\n",
+    "from rime_sdk import Client"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install https://github.com/RobustIntelligence/ri-public-examples/archive/master.zip\n",
+    "    \n",
+    "from ri_public_examples.download_files import download_files\n",
+    "\n",
+    "download_files('tabular-2.0/ranking', 'ranking')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "YilAj33W_5y-"
+   },
+   "source": [
+    "## **Establish the RIME Client**\n",
+    "\n",
+    "To get started, provide the API credentials and the base domain/address of the RIME service. You can generate and copy an API token from the API Access Tokens Page under Workspace settings. For the domian/address of the RIME service, contact your admin. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "90zo7hdkmKyW"
+   },
+   "source": [
+    "![img_1](https://drive.google.com/uc?id=1vMDhZii8yq22iuqSM8-Vqt3sZ2F3tPyz)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "sPOXz25dEiDQ"
+   },
+   "outputs": [],
+   "source": [
+    "API_TOKEN = '' # PASTE API_KEY \n",
+    "CLUSTER_URL = '' # PASTE DEDICATED DOMAIN OF RIME SERVICE (eg: rime.stable.rbst.io)\n",
+    "AGENT_ID = '' # PASTE AGENT_ID IF USING AN AGENT THAT IS NOT THE DEFAULT\n",
+    "client = Client(CLUSTER_URL, API_TOKEN)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "UePxMUdoAFOH"
+   },
+   "source": [
+    "## **Create a New Project**\n",
+    "\n",
+    "You can create projects in RIME to organize your test runs. Each project represents a workspace for a given machine learning task. It can contain multiple candidate models, but should only contain one promoted production model. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "Of1LzaEOAGLz"
+   },
+   "outputs": [],
+   "source": [
+    "description = (\n",
+    "    \"Run Stress Testing and AI Continuous Testing on a point-wise\"\n",
+    "    \" tabular ranking model and dataset. Demonstration uses a\"\n",
+    "    \" movie ranking dataset.\"\n",
+    ")\n",
+    "project = client.create_project(\n",
+    "    name='Tabular Ranking Demo',\n",
+    "    description=description,\n",
+    "    model_task='MODEL_TASK_RANKING'\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "l4Z7t5FSAQLW"
+   },
+   "source": [
+    "**Go back to the UI to see the new Ranking Demo Project.**"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## **Uploading the Model + Datasets**"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "NctleDA3P05v"
+   },
+   "source": [
+    "Next, let's take a quick look at the training data (in this case, this was the data used to train the model):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "rS6ST9KhZPEp"
+   },
+   "outputs": [],
+   "source": [
+    "df = pd.read_csv(Path('ranking/data/ref.csv'))\n",
+    "df.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "KdCnsy-RNh8Q"
+   },
+   "outputs": [],
+   "source": [
+    "upload_path = \"ri_public_examples_ranking\"\n",
+    "\n",
+    "model_s3_dir = client.upload_directory(\n",
+    "    Path('ranking/models'), upload_path=upload_path\n",
+    ")\n",
+    "model_s3_path = model_s3_dir + \"/model_extras/model.py\"\n",
+    "\n",
+    "ref_s3_path = client.upload_file(\n",
+    "    Path('ranking/data/ref.csv'), upload_path=upload_path\n",
+    ")\n",
+    "eval_s3_path = client.upload_file(\n",
+    "    Path('ranking/data/eval.csv'), upload_path=upload_path\n",
+    ")\n",
+    "\n",
+    "ref_preds_s3_path = client.upload_file(\n",
+    "    Path(\"ranking/data/ref_preds.csv\"), upload_path=upload_path\n",
+    ")\n",
+    "eval_preds_s3_path = client.upload_file(\n",
+    "    Path(\"ranking/data/eval_preds.csv\"), upload_path=upload_path\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Once the data and model are uploaded to S3, we can register them to RIME. Once they're registered, we can refer to these resources using their RIME-generated ID's."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from datetime import datetime\n",
+    "\n",
+    "dt = str(datetime.now())\n",
+    "\n",
+    "# Note: models and datasets need to have unique names.\n",
+    "model_id = project.register_model_from_path(f\"model_{dt}\", model_s3_path, agent_id=AGENT_ID)\n",
+    "\n",
+    "data_params = {\n",
+    "    \"label_col\": \"rank_label\",\n",
+    "    \"ranking_info\": {\n",
+    "      \"query_col\": \"query_id\"\n",
+    "    },\n",
+    "    \"protected_features\": [\"Director\", \"Cast1\"],\n",
+    "}\n",
+    "ref_dataset_id = project.register_dataset_from_file(\n",
+    "    f\"ref_dataset_{dt}\", ref_s3_path, data_params=data_params, agent_id=AGENT_ID\n",
+    ")\n",
+    "eval_dataset_id = project.register_dataset_from_file(\n",
+    "    f\"eval_dataset_{dt}\", eval_s3_path, data_params=data_params, agent_id=AGENT_ID\n",
+    ")\n",
+    "pred_params = {\"pred_col\": \"pred\"}\n",
+    "project.register_predictions_from_file(\n",
+    "    ref_dataset_id, model_id, ref_preds_s3_path, pred_params=pred_params, agent_id=AGENT_ID\n",
+    ")\n",
+    "project.register_predictions_from_file(\n",
+    "    eval_dataset_id, model_id, eval_preds_s3_path, pred_params=pred_params, agent_id=AGENT_ID\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "9vtJnRnBBqkp"
+   },
+   "source": [
+    "## **Running a Stress Test**\n",
+    "\n",
+    "AI Stress Tests allow you to test your data and model before deployment. They are a comprehensive suite of hundreds of tests that automatically identify implicit assumptions and weaknesses of pre-production models. Each stress test is run on a single model and its associated reference and evaluation datasets.\n",
+    "\n",
+    "Below is a sample configuration of how to setup and run a RIME Stress Test."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "PfzT-SAhpi-x"
+   },
+   "outputs": [],
+   "source": [
+    "stress_test_config = {\n",
+    "    \"run_name\": \"Movie Ranking\", \n",
+    "    \"data_info\": {\n",
+    "        \"ref_dataset_id\": ref_dataset_id, \n",
+    "        \"eval_dataset_id\": eval_dataset_id,\n",
+    "    }, \n",
+    "    \"model_id\": model_id,\n",
+    "    \"categories\": [\"TEST_CATEGORY_TYPE_ADVERSARIAL\", \"TEST_CATEGORY_TYPE_SUBSET_PERFORMANCE\", \"TEST_CATEGORY_TYPE_TRANSFORMATIONS\", \"TEST_CATEGORY_TYPE_BIAS_AND_FAIRNESS\"]\n",
+    "}\n",
+    "stress_job = client.start_stress_test(\n",
+    "    stress_test_config, project.project_id, agent_id=AGENT_ID\n",
+    ")\n",
+    "stress_job.get_status(verbose=True, wait_until_finish=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "S2x2K9h1B6oX"
+   },
+   "source": [
+    "## **Stress Test Results**\n",
+    "\n",
+    "Stress tests are grouped into categories that measure various aspects of model robustness (model behavior, distribution drift, abnormal input, transformations, adversarial attacks, data cleanliness). Suggestions to improve your model are aggregated on the category level as well. Tests are ranked by default by a shared severity metric. Clicking on an individual test surfaces more detailed information. \n",
+    "\n",
+    "\n",
+    "You can view the detailed results in the UI by running the below cell and redirecting to the generated link. This page shows granular results for a given AI Stress Test run. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "DAfObkwHB0xy"
+   },
+   "outputs": [],
+   "source": [
+    "test_run = stress_job.get_test_run()\n",
+    "test_run"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "_8ajygi1E71f"
+   },
+   "source": [
+    "Stress testing should be used during model development to inform us about various issues with the data and model that we might want to address before the model is deployed. The information is presented in an incident management view."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "1zKDo7TOYYds",
+    "tags": []
+   },
+   "source": [
+    "### **Analyzing the Results**\n",
+    "\n",
+    "Below you can see a snapshot of the results. \n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "h2jQYUDmknsU"
+   },
+   "source": [
+    "![img_2](https://drive.google.com/uc?id=1gR-bosz3YH4wX2W2M4scjCdIz0RRjoig)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "1oO26DNFoJQV"
+   },
+   "source": [
+    "Here are the results of the Subset Performance tests. These tests can be thought as more detailed performance tests that identify subsets of underperformance. These tests help ensure that the model works equally well across different groups."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "Nc1TzYeqkn1k"
+   },
+   "source": [
+    "![img_3](https://drive.google.com/uc?id=1ATu9N3jjKm26nKUwehjrCG1yepzIOz9c)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "EfnKH70fpmmu"
+   },
+   "source": [
+    "Below we are exploring the \"Subset Mean Reciprocal Rank (MRR)\" test cases for the feature \"Votes\". We can see that even though the model has an overall MRR of 0.91, it performs poorly on certain subsets with low values of the \"Votes\" feature."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "g91I82zRkoH5"
+   },
+   "source": [
+    "![img_4](https://drive.google.com/uc?id=1Px7l7mc6W5MIdm1RJDY9Gfgg40amdVUi)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "AzP97mzuab3m"
+   },
+   "source": [
+    "## **Deploy to Production and set up Continuous Testing**\n",
+    "\n",
+    "Once you have identified the best stress test run, you can deploy the associated model and set up Continuous Testing in order to automatically detect “bad” incoming data and statistically significant distributional drift."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "swErpZi1OE80"
+   },
+   "outputs": [],
+   "source": [
+    "from datetime import timedelta\n",
+    "\n",
+    "ct_instance = project.create_ct(model_id, ref_dataset_id, timedelta(days=1))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "a0Lw2YBXBkb4"
+   },
+   "source": [
+    "## **Uploading a Batch of Production Data & Model Predictions to Continuous Testing**\n",
+    "\n",
+    "The model has been in production for some time, and new production data and model predictions have been collected and stored. Now, we will use Continuous Testing to track how the model performed. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "g7McYwfDUztC"
+   },
+   "source": [
+    "**Upload the Latest Batch of Production Data**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "zsmlbMIFUzAy"
+   },
+   "outputs": [],
+   "source": [
+    "dt = str(datetime.now())\n",
+    "prod_s3_path = client.upload_file(\n",
+    "    Path('ranking/data/test.csv'), \n",
+    "    upload_path=upload_path,\n",
+    ")\n",
+    "prod_dataset_id = project.register_dataset_from_file(\n",
+    "    f\"prod_dataset_{dt}\", \n",
+    "    prod_s3_path, \n",
+    "    data_params={\"timestamp_col\": \"timestamp\", \"protected_features\": [\"Director\", \"Cast1\"], **data_params},\n",
+    "    agent_id=AGENT_ID\n",
+    ")\n",
+    "prod_preds_s3_path = client.upload_file(\n",
+    "    Path('ranking/data/test_preds.csv'), \n",
+    "    upload_path=upload_path,\n",
+    ")\n",
+    "project.register_predictions_from_file(\n",
+    "    prod_dataset_id, \n",
+    "    model_id,\n",
+    "    prod_preds_s3_path, \n",
+    "    pred_params=pred_params,\n",
+    "    agent_id=AGENT_ID\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "project.update_continuous_test_categories([\"TEST_CATEGORY_TYPE_MODEL_PERFORMANCE\",\n",
+    "                                           \"TEST_CATEGORY_TYPE_SUBSET_PERFORMANCE_DEGRADATION\",\n",
+    "                                           \"TEST_CATEGORY_TYPE_ABNORMAL_INPUTS\",\n",
+    "                                           \"TEST_CATEGORY_TYPE_DRIFT\",\n",
+    "                                           \"TEST_CATEGORY_TYPE_BIAS_AND_FAIRNESS\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "e-ooaBT-U4yr"
+   },
+   "source": [
+    "**Run Continuous Testing over Batch of Data**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "EHxteK1gUklo"
+   },
+   "outputs": [],
+   "source": [
+    "ct_job = ct_instance.start_continuous_test(prod_dataset_id, agent_id=AGENT_ID)\n",
+    "ct_job.get_status(verbose=True, wait_until_finish=True)\n",
+    "ct_instance"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "ifxKz_p6Uc63"
+   },
+   "source": [
+    "**Wait for a couple minutes and your results will appear in the UI.**"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "## **Querying Results from Continuous Testing**"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "After Continuous Testing has been set up and data has been uploaded for processing, the user can query the results throughout the entire uploaded history."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Obtain All Detection Events**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "events = [d.to_dict() for m in ct_instance.list_monitors() for d in m.list_detected_events()]\n",
+    "events_df = pd.DataFrame(events).drop([\"id\", \"project_id\", \"firewall_id\", \"event_object_id\", \"description_html\", \"last_update_time\"], axis=1)\n",
+    "events_df.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "MzMea8BUFOT1"
+   },
+   "source": [
+    "## **CT Results**\n",
+    "\n",
+    "The Continuous Tests operate at the batch level and provide a mechanism to monitor the health of ML deployments in production. They allow the user to understand when errors begin to occur and surface the underlying drivers of such errors. \n",
+    "\n",
+    "You can explore the results in the UI by running the below cell and redirecting to the generated link.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "Qndn2zUMLhJo"
+   },
+   "outputs": [],
+   "source": [
+    "ct_instance"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "ycu422woQkoA",
+    "tags": []
+   },
+   "source": [
+    "### **Analyzing CT Results**\n",
+    "\n",
+    "**Failing Rows Rate stays steady (and low) over time** - In the below image, we can see that the Failing Rows Rate remains fairly low (<15%) over time, and does not trend upward significantly."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "AFuGGg8uNtC2"
+   },
+   "source": [
+    "![img_5](https://drive.google.com/uc?id=15Q5bmKWTmoG9tE0TovW0AM9t2j7kARQS)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "qPAgDrQkEA8d",
+    "jp-MarkdownHeadingCollapsed": true,
+    "tags": []
+   },
+   "source": [
+    "## Summary:\n",
+    "In this Notebook, RIME and the SDK helped with ingesting and investigating tabular pointwise ranking information which:\n",
+    "\n",
+    "✅ Measured impact of failing tests on model performance\n",
+    "\n",
+    "✅ Assisted with modeling and experiment tracking\n",
+    "\n",
+    "✅ Identified root-cause analysis of underlying issues in data and model (e.g. Numerical Outliers and Bad Inputs)\n",
+    "\n",
+    "✅ Continuously testing production data and model which enforced better ml integrity and posture (e.g. Highlighting changes in data schema, data malformations, cardinality changes, out of range values, missing values)\n",
+    "\n",
+    "\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "colab": {
+   "collapsed_sections": [],
+   "name": "RIME_Ranking_Walkthrough.ipynb",
+   "provenance": []
+  },
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.17"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/notebooks/demo_notebooks/RIME_Regression_Walkthrough.ipynb
+++ b/notebooks/demo_notebooks/RIME_Regression_Walkthrough.ipynb
@@ -1,0 +1,408 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "2juKKWiBUqM3"
+   },
+   "source": [
+    "# **RI NYC Taxi and Limousine Data Walkthrough** 🚖\n",
+    "\n",
+    "> ▶️ **Try this in Colab!** Run the [RI NYC Taxi and Limousine Data Walkthrough in Google Colab](https://colab.research.google.com/github/RobustIntelligence/docs/blob/main/notebooks/demo_notebooks/RIME_Regression_Walkthrough.ipynb). \n",
+    "\n",
+    "In this walkthrough, we'll run AI Stress Testing and AI Continuous Testing on public NYC Taxi and Limousine Commission data (https://www.nyc.gov/site/tlc/about/tlc-trip-record-data.page) to demonstrate how RIME can be used with regression models. This data consists of information such as the pickup and dropoff locations, pickup and dropoff times, fare amounts and the number of passengers for every taxi trip that happens in New York City. We'll be predicting the duration of each trip given a bunch of other information about the trip.\n",
+    "\n",
+    "As you might imagine, the COVID-19 pandemic caused a significant change in the number and nature of the taxi rides that occur in New York City. We've included data from 2018 to 2021 for this walkthrough to demonstrate how AI Continuous Testing can help you identify and understand such distribution drifts.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "cHB5JnkFNdOZ"
+   },
+   "source": [
+    "To get started, provide the API credentials and link to the backend of RIME to connect the instance."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "Nqhw1HbENlgz"
+   },
+   "outputs": [],
+   "source": [
+    "API_TOKEN = '' # PASTE API_KEY \n",
+    "CLUSTER_URL = '' # PASTE DEDICATED DOMAIN OF RIME SERVICE (eg: rime.stable.rbst.io)\n",
+    "AGENT_ID = '' # PASTE AGENT_ID IF USING AN AGENT THAT IS NOT THE DEFAULT"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "LZXhwB6bMCDt"
+   },
+   "source": [
+    "## Libraries 📕\n",
+    "Run the cell below to install libraries to receive data, install our SDK, and load analysis libraries.\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "NAlM-eMxL9W5"
+   },
+   "outputs": [],
+   "source": [
+    "!pip install rime-sdk &> /dev/null"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "NAlM-eMxL9W5"
+   },
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "from pathlib import Path\n",
+    "from rime_sdk import Client "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "kN0xMjsRMlkx"
+   },
+   "source": [
+    "## Data and Model ☁️\n",
+    "Run the cell below to download and unzip a preprocessed dataset and pretrained model based on public NYC Taxi and Limousine Commission data."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install git+https://github.com/RobustIntelligence/ri-public-examples.git\n",
+    "from ri_public_examples.download_files import download_files\n",
+    "download_files('tabular-2.0/nyc_tlc', 'nyc_tlc')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "s59pzJdnbFBQ"
+   },
+   "source": [
+    "Next, let's take a quick look at the reference data (in this case, this was the data used to train the model)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 427
+    },
+    "id": "mWr4uIoNau8N",
+    "outputId": "47944289-584a-41d1-9597-a3e371b2d743"
+   },
+   "outputs": [],
+   "source": [
+    "pd.read_csv(\"nyc_tlc/data/ref.csv\", nrows=5)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "RjdT3Jv-b6U9"
+   },
+   "source": [
+    "The key columns to look at above are the `TripDuration`, the duration of the trip in seconds, and `Prediction`, our model's estimate of the duration of the trip. The other columns are features used by the model to help predict the trip duration. We'll now proceed to run RIME Stress Testing on our data and model! We'll start by creating a project and uploading our datasets and model."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "client = Client(CLUSTER_URL, API_TOKEN)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "Y0E0wSyHMhMj",
+    "outputId": "24123ad6-eb99-4541-9975-8077ccaef9c3"
+   },
+   "outputs": [],
+   "source": [
+    "description = (\n",
+    "    \"Run Stress Testing and Continuous Testing on a\"\n",
+    "    \" tabular regression model and dataset. Demonstration uses the\"\n",
+    "    \" NYC Taxi and Limousine Commission trip duration dataset\"\n",
+    "    \" (https://www.nyc.gov/site/tlc/about/tlc-trip-record-data.page).\"\n",
+    ")\n",
+    "project = client.create_project(\n",
+    "    'Tabular Regression Demo', \n",
+    "    description,\n",
+    "    \"MODEL_TASK_REGRESSION\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from datetime import datetime\n",
+    "\n",
+    "# Note: All registered models and datasets need to have unique names.\n",
+    "dt = str(datetime.now())\n",
+    "upload_path = \"ri_public_examples_nyc_tlc\"\n",
+    "\n",
+    "model_s3_path = client.upload_directory(Path(\"nyc_tlc/models\"), upload_path=upload_path)\n",
+    "model_id = project.register_model_from_path(f\"model_{dt}\", model_s3_path + \"/model.py\", agent_id=AGENT_ID)\n",
+    "\n",
+    "def upload_and_register_data(dataset, **kwargs):\n",
+    "    s3_path = client.upload_file(Path(f\"nyc_tlc/data/{dataset}.csv\"), upload_path=upload_path)\n",
+    "    dataset_id = project.register_dataset_from_file(f\"{dataset}_{dt}\", s3_path, {\"label_col\": \"TripDuration\", \n",
+    "                                                                                 \"protected_features\": [\"PULocationID\", \"TipAmount\"],\n",
+    "                                                                                 **kwargs}, agent_id=AGENT_ID)\n",
+    "    preds_s3_path = client.upload_file(Path(f\"nyc_tlc/data/{dataset}_preds.csv\"), upload_path=upload_path)\n",
+    "    project.register_predictions_from_file(dataset_id, model_id, preds_s3_path, agent_id=AGENT_ID)\n",
+    "    return dataset_id\n",
+    "\n",
+    "ref_id = upload_and_register_data(\"ref\")\n",
+    "eval_id = upload_and_register_data(\"eval\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## AI Stress Testing"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "Lf1ylzMJGKJ0"
+   },
+   "source": [
+    "Next, we'll create a stress testing configuration specifying relevant metadata for our datasets and model and run stress testing! When running stress testing, the reference data should be data used to train the model, and the evaluation data should be data used to evaluate the model. In this case, the reference and evaluation datasets are random splits of the NYC TLC data collected from 2018."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "YA4OxHAiO9g7",
+    "outputId": "e768bc61-8aeb-460e-8dec-497f84ffe6ba"
+   },
+   "outputs": [],
+   "source": [
+    "stress_test_config = {\n",
+    "  \"run_name\": \"NYC TLC\",\n",
+    "  \"data_info\": {\n",
+    "    \"ref_dataset_id\": ref_id,\n",
+    "    \"eval_dataset_id\": eval_id,\n",
+    "  },\n",
+    "  \"model_id\": model_id,\n",
+    "  \"categories\": [\"TEST_CATEGORY_TYPE_ADVERSARIAL\", \"TEST_CATEGORY_TYPE_SUBSET_PERFORMANCE\", \"TEST_CATEGORY_TYPE_TRANSFORMATIONS\", \"TEST_CATEGORY_TYPE_BIAS_AND_FAIRNESS\"]\n",
+    "}\n",
+    "stress_test_job = client.start_stress_test(\n",
+    "    stress_test_config, \n",
+    "    project.project_id,\n",
+    "    agent_id=AGENT_ID,\n",
+    ")\n",
+    "stress_test_job.get_status(verbose=True, wait_until_finish=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You can view the detailed results in the UI by running the below cell and redirecting to the generated link. This page shows granular results for a given AI Stress Test run. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "test_run = stress_test_job.get_test_run()\n",
+    "test_run"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "F_lMRyPxQJX7"
+   },
+   "source": [
+    "Stress testing should be used during model development to inform us about various issues with the data and model that we might want to address before the model is deployed."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "nidRlmx8Po9G"
+   },
+   "source": [
+    "![img_1](https://drive.google.com/uc?id=1tzZWlSIb-r5vwaWxqjrk0IqZT-53hRhI)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## AI Continuous Testing"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "u7WJksWqRFge"
+   },
+   "source": [
+    "In this walkthrough, we'll be focusing on the _production_ setting where we've deployed a model and would like to ensure that it continues to perform well as the underlying data drifts and evolves. For this we'll need to set up and perform AI Continuous Testing. Run the following snippet to set up continuous testing to split the data into 4 week bins."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from datetime import timedelta\n",
+    "\n",
+    "ct_instance = project.create_ct(model_id, ref_id, timedelta(weeks=4))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "HRgljOaeRa5X"
+   },
+   "source": [
+    "Next, we'll upload some incoming production data. The data we're uploading here is from 2019 through to 2021, which will look substantially different from what the model saw in its training data from 2018 (the data will be automatically split into pieces based on the timestamps specified and the bin size set for this AI Continuous Testing instance). We'll use AI Continuous Testing to identify the differences and understand how they're impacting our model."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "prod_dataset_id = upload_and_register_data(\"test\", timestamp_col=\"PickupDatetime\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "project.update_continuous_test_categories([\"TEST_CATEGORY_TYPE_MODEL_PERFORMANCE\",\n",
+    "                                           \"TEST_CATEGORY_TYPE_SUBSET_PERFORMANCE_DEGRADATION\",\n",
+    "                                           \"TEST_CATEGORY_TYPE_ABNORMAL_INPUTS\",\n",
+    "                                           \"TEST_CATEGORY_TYPE_DRIFT\",\n",
+    "                                           \"TEST_CATEGORY_TYPE_BIAS_AND_FAIRNESS\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "jUD1ZBNyg0LM",
+    "outputId": "26393984-96d0-42d0-898c-432f9e5479d8"
+   },
+   "outputs": [],
+   "source": [
+    "ct_job = ct_instance.start_continuous_test(prod_dataset_id, agent_id=AGENT_ID)\n",
+    "ct_job.get_status(verbose=True, wait_until_finish=True)\n",
+    "ct_instance"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "eFkrep_aUswK"
+   },
+   "source": [
+    "Time to see how our model is doing! Navigate to the \"Continuous Tests\" tab on the left nav. Here, you'll see some of the key metrics that are being tracked over time."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "0_f7cTHfWcEv"
+   },
+   "source": [
+    "![img_2](https://drive.google.com/uc?id=1P5m239sHLXF0EZ9MIDD2mhe_m9PsErWB)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "N939LDZ_fmna"
+   },
+   "source": [
+    "We can inspect the input data for failing input values. The overall failing rows rate shows the percent of failing inputs (for all types of failing tests including outliers, missing values, unseen categories) over time. We can see that there's a spike in the failing rows rate in early 2021 after which it remains high."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "![abnormality_rate](https://drive.google.com/uc?id=1z2EZD7R15HF91f2Bjjsomzkdgb_8eNBX)"
+   ]
+  }
+ ],
+ "metadata": {
+  "colab": {
+   "collapsed_sections": [],
+   "name": "RIME_Regression_Walkthrough.ipynb",
+   "provenance": []
+  },
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.17"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/notebooks/feature_notebooks/RI_Scheduled_CT.ipynb
+++ b/notebooks/feature_notebooks/RI_Scheduled_CT.ipynb
@@ -1,0 +1,391 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "57223d3b-951f-43fc-aee7-7f2febbad96c",
+   "metadata": {},
+   "source": [
+    "# Scheduled Continuous Testing"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "63f11b92-86c2-4292-9469-3995dfb90cd1",
+   "metadata": {},
+   "source": [
+    "**Instantiate RIME client and create a new project**\n",
+    "\n",
+    "Let's begin by creating a new client connection to our Robust Intelligence cluster."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "020a469c-a549-4857-a303-efc6a79119ae",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from rime_sdk import Client\n",
+    "\n",
+    "API_TOKEN = '' # PASTE API_KEY \n",
+    "CLUSTER_URL = '' # PASTE DEDICATED DOMAIN OF RIME SERVICE (eg: rime.stable.rbst.io)\n",
+    "AGENT_ID = '' # PASTE AGENT_ID IF USING AN AGENT THAT IS NOT THE DEFAULT\n",
+    "\n",
+    "client = Client(CLUSTER_URL, API_TOKEN)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3af0ffae-aed2-4ed2-947f-1b8f9f985fa4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "description = (\n",
+    "    \"Create a Continuous Test and set up scheduling.\"\n",
+    "    \" Demonstration uses a tabular binary classification dataset\"\n",
+    "    \" and model that simulates credit card fraud detection.\"\n",
+    ")\n",
+    "project = client.create_project(\n",
+    "    \"Scheduled Continuous Testing Demo\", \n",
+    "    description,\n",
+    "    \"MODEL_TASK_BINARY_CLASSIFICATION\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "52be1935-95e2-4695-a78c-b04f70ea06ee",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "project_id = project.project_id\n",
+    "\n",
+    "# You can always retrieve a project when re-running the notebook by using its id\n",
+    "project = client.get_project(project_id)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "28538d07-bb51-46cf-8fb7-46066f4c76ef",
+   "metadata": {},
+   "source": [
+    "**Create a custom loader function to retrieve data from S3**\n",
+    "\n",
+    "There are many ways for Continuous Testing (CT) to load in your data. In this example, we'll write a Python function to generate data and store the function on S3.\n",
+    "\n",
+    "The Python function will take in the following parameters:\n",
+    "\n",
+    "- `start_time`: Required for scheduled CT. This is needed to grab the proper data based on time.\n",
+    "- `end_time`: Required for scheduled CT. This is needed to grab the proper data based on time.\n",
+    "- `ref_data`: Custom parameter for this function (you can add your own custom parameters and let RI know about them once you register your dataset). Returns reference or evaluation dataset for this example notebook based on the value of the boolean.\n",
+    "- `preds_only`: Custom parameter for this function (you can add your own custom parameters and let Robust Intelligence know about them once you register your dataset). Returns the actual data or just the predictions for this example notebook based on the value of the boolean.\n",
+    "\n",
+    "We'll put this function into a `.py` file and upload it to an S3 bucket. Then, later in the notebook, we will set up our project to download and call this function to generate data to use with CT runs."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "72c93b1e-6dc0-4f95-bce3-5aabff4bea14",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\"\"\"Custom loader for fraud datasets from S3.\"\"\"\n",
+    "from datetime import datetime\n",
+    "\n",
+    "import pandas as pd\n",
+    "import subprocess\n",
+    "import sys\n",
+    "\n",
+    "def custom_data_loader_func(\n",
+    "    start_time: datetime, # Note: Required for scheduled CT\n",
+    "    end_time: datetime, # Note: Required for scheduled CT\n",
+    "    ref_data: bool,\n",
+    "    preds_only: bool,\n",
+    ") -> pd.DataFrame:\n",
+    "    # Load the data\n",
+    "    subprocess.check_call([sys.executable, \"-m\", \"pip\", \"install\", \"https://github.com/RobustIntelligence/ri-public-examples/archive/master.zip\"])\n",
+    "\n",
+    "    from ri_public_examples.download_files import download_files\n",
+    "    download_files('tabular-2.0/fraud', 'fraud')\n",
+    "\n",
+    "    ct_data = (pd.read_csv(\"fraud/data/fraud_incremental_preds.csv\")\n",
+    "               if preds_only\n",
+    "               else pd.read_csv(\"fraud/data/fraud_incremental.csv\"))\n",
+    "\n",
+    "    if ref_data:\n",
+    "        return ct_data[:len(ct_data)//2]\n",
+    "    else:\n",
+    "        return ct_data[len(ct_data)//2:]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "115bb4a0-ef92-437e-8332-f6fbace1dddd",
+   "metadata": {},
+   "source": [
+    "**Create an integration to S3**\n",
+    "\n",
+    "We need to set up an S3 integration with credential information to be able to properly download the data loading Python file from our S3 bucket. You can find additional information on how to create integrations [here](https://docs.rime.dev/en/latest/administration/workspace_configuration/integrations.html)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4bcf5c45-66a5-40ba-8897-d8f4f72e81c5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "WORKSPACE_ID = '' # PASTE WORKSPACE_ID\n",
+    "AWS_ACCESS_KEY_ID = '' # PASTE AWS ACCESS KEY ID WITH ACCESS TO YOUR S3 BUCKET\n",
+    "AWS_SECRET_ACCESS_KEY = '' # PASTE AWS SECRET ACCESS KEY WITH ACCESS TO YOUR S3 BUCKET\n",
+    "\n",
+    "S3_INTEGRATION_ID = client.create_integration(\n",
+    "    workspace_id=WORKSPACE_ID,\n",
+    "    name=\"s3 integration\",\n",
+    "    integration_type=\"INTEGRATION_TYPE_AWS_ACCESS_KEY\",\n",
+    "    integration_schema=[\n",
+    "        {\n",
+    "            \"name\": \"AWS_ACCESS_KEY_ID\",\n",
+    "            \"sensitivity\": \"VARIABLE_SENSITIVITY_PUBLIC\",\n",
+    "            \"value\": AWS_ACCESS_KEY_ID,\n",
+    "        },\n",
+    "        {\n",
+    "            \"name\": \"AWS_SECRET_ACCESS_KEY\",\n",
+    "            \"sensitivity\": \"VARIABLE_SENSITIVITY_WORKSPACE_SECRET\",\n",
+    "            \"value\": AWS_SECRET_ACCESS_KEY,\n",
+    "        },\n",
+    "    ],\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e71fd9cb-6b33-45a5-b7fd-52a76b3b5a50",
+   "metadata": {},
+   "source": [
+    "**Register datasets with the project**\n",
+    "\n",
+    "To start a CT run, we need to register our model (optional), datasets and predictions (required if model is not specified) with the project. For dataset registration, we need to specify:\n",
+    "\n",
+    "- the S3 path to the Python file\n",
+    "- the name of the data loading function in the Python file\n",
+    "- the list of custom parameters required by the function (e.g., `ref_data`, `preds_only`)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "69d671a0-f85f-4c76-8af0-b504d42c2eea",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dt = str(datetime.now())\n",
+    "\n",
+    "# Note: models and datasets need to have unique names.\n",
+    "model_id = project.register_model(f\"fraud_model_{dt}\", None, agent_id=AGENT_ID)\n",
+    "\n",
+    "ref_data_id = project.register_dataset(\n",
+    "    name=f\"fraud_reference_dataset{dt}\",\n",
+    "    data_config={\n",
+    "        \"connection_info\": {\"data_loading\": {\n",
+    "            \"path\": \"s3://pranay-scheduled-ct-test/s3_fraud_custom_loader.py\",\n",
+    "            \"load_func_name\": \"custom_data_loader_func\",\n",
+    "            \"loader_kwargs_json\": \"{\\\"ref_data\\\": true, \\\"preds_only\\\": false}\",\n",
+    "        }},\n",
+    "        \"data_params\": {\n",
+    "            \"label_col\": \"label\",\n",
+    "            \"timestamp_col\": \"timestamp\",\n",
+    "        },\n",
+    "    },\n",
+    "    integration_id=S3_INTEGRATION_ID,\n",
+    "    agent_id=AGENT_ID,\n",
+    ")\n",
+    "\n",
+    "project.register_predictions(\n",
+    "    dataset_id=ref_data_id,\n",
+    "    model_id=model_id,\n",
+    "    pred_config={\n",
+    "        \"connection_info\": {\"data_loading\": {\n",
+    "            \"path\": \"s3://pranay-scheduled-ct-test/s3_fraud_custom_loader.py\",\n",
+    "            \"load_func_name\": \"custom_data_loader_func\",\n",
+    "            \"loader_kwargs_json\": \"{\\\"ref_data\\\": true, \\\"preds_only\\\": true}\",\n",
+    "        }},\n",
+    "        \"pred_params\": {\n",
+    "            \"pred_col\": \"preds\",\n",
+    "        },\n",
+    "    },\n",
+    "    integration_id=S3_INTEGRATION_ID,\n",
+    "    agent_id=AGENT_ID,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "41aaab2c-5c39-4083-bfc8-28881a334754",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "eval_data_id = project.register_dataset(\n",
+    "    name=f\"fraud_evaluation_dataset{dt}\",\n",
+    "    data_config={\n",
+    "        \"connection_info\": {\"data_loading\": {\n",
+    "            \"path\": \"s3://pranay-scheduled-ct-test/s3_fraud_custom_loader.py\",\n",
+    "            \"load_func_name\": \"custom_data_loader_func\",\n",
+    "            \"loader_kwargs_json\": \"{\\\"ref_data\\\": false, \\\"preds_only\\\": false}\",\n",
+    "        }},\n",
+    "        \"data_params\": {\n",
+    "            \"label_col\": \"label\",\n",
+    "            \"timestamp_col\": \"timestamp\",\n",
+    "        },\n",
+    "    },\n",
+    "    integration_id=S3_INTEGRATION_ID,\n",
+    "    agent_id=AGENT_ID,\n",
+    ")\n",
+    "\n",
+    "project.register_predictions(\n",
+    "    dataset_id=eval_data_id,\n",
+    "    model_id=model_id,\n",
+    "    pred_config={\n",
+    "        \"connection_info\": {\"data_loading\": {\n",
+    "            \"path\": \"s3://pranay-scheduled-ct-test/s3_fraud_custom_loader.py\",\n",
+    "            \"load_func_name\": \"custom_data_loader_func\",\n",
+    "            \"loader_kwargs_json\": \"{\\\"ref_data\\\": false, \\\"preds_only\\\": true}\",\n",
+    "        }},\n",
+    "        \"pred_params\": {\n",
+    "            \"pred_col\": \"preds\",\n",
+    "        },\n",
+    "    },\n",
+    "    integration_id=S3_INTEGRATION_ID,\n",
+    "    agent_id=AGENT_ID,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a04f977e-2a49-4061-b7c8-0e5771f44b94",
+   "metadata": {},
+   "source": [
+    "**Test everything out with a manual CT run**\n",
+    "\n",
+    "We don't want to wait until a scheduled CT run in the future to surface small mistakes (e.g., a typo in the S3 path). We can create a new CT instance and start a manual run to verify that our configuration works as intended before activating scheduling.\n",
+    "\n",
+    "NOTE: Data needs to exist and be returned for every time bin. If there is no data for a bin, an error will be returned."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "de8e92b0-925e-4d21-9ab1-b5f9a3c23015",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from datetime import timedelta\n",
+    "\n",
+    "ct = project.create_ct(model_id, ref_data_id, bin_size=timedelta(days=1))\n",
+    "\n",
+    "# If you are re-running this notebook and already have created CT for the project, you can retrieve and update the CT object.\n",
+    "# ct = project.get_ct()\n",
+    "# ct.update_ct(ref_data_id=ref_data_id)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1c675a27-4fe7-4f50-82ef-ee9337c7de70",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ct_job = ct.start_continuous_test(eval_data_id, override_existing_bins=True, agent_id=AGENT_ID)\n",
+    "ct_job.get_status(verbose=True, wait_until_finish=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2e05f876-2404-463f-a10f-441912ef14a8",
+   "metadata": {},
+   "source": [
+    "**Activate Scheduled Continuous Testing**\n",
+    "\n",
+    "After verifying that CT can successfully load in our data, run tests and push the results to the Robust Intelligence UI, we are ready to activate scheduled CT."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3181267d-743c-48d9-bf99-733a6fe28277",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ct.activate_ct_scheduling(\n",
+    "    data_info={\n",
+    "        \"connection_info\": {\"data_loading\": {\n",
+    "            \"path\": \"s3://pranay-scheduled-ct-test/s3_fraud_custom_loader_scheduled_ct.py\",\n",
+    "            \"load_func_name\": \"custom_data_loader_func\",\n",
+    "            \"loader_kwargs_json\": \"{\\\"ref_data\\\": false, \\\"preds_only\\\": false}\",\n",
+    "        }},\n",
+    "        \"data_params\": {\n",
+    "            \"label_col\": \"label\",\n",
+    "            \"timestamp_col\": \"timestamp\",\n",
+    "        },\n",
+    "    },\n",
+    "    data_integration_id=S3_INTEGRATION_ID,\n",
+    "    pred_integration_id=S3_INTEGRATION_ID,\n",
+    "    pred_info={\n",
+    "        \"connection_info\": {\"data_loading\": {\n",
+    "            \"path\": \"s3://pranay-scheduled-ct-test/s3_fraud_custom_loader_scheduled_ct.py\",\n",
+    "            \"load_func_name\": \"custom_data_loader_func\",\n",
+    "            \"loader_kwargs_json\": \"{\\\"ref_data\\\": false, \\\"preds_only\\\": true}\",\n",
+    "        }},\n",
+    "        \"pred_params\": {\n",
+    "            \"pred_col\": \"preds\",\n",
+    "        },\n",
+    "    },\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "970ff72f-8556-462c-8492-5c3aa211ff24",
+   "metadata": {},
+   "source": [
+    "**Some additional methods to work with Scheduled CT**\n",
+    "\n",
+    "```python\n",
+    "# Find the schedule for CT\n",
+    "ct.get_scheduled_ct_info()\n",
+    "\n",
+    "# Deactivate the schedule for CT\n",
+    "ct.deactivate_ct_scheduling()\n",
+    "\n",
+    "# Update the reference dataset for a scheduled Continuous Test\n",
+    "ct.update_ct(ref_data_id=new_ref_data_id)\n",
+    "```"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.18"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Restore the 2.3 editions of the Notebooks so that they will appear on Colab.

Older versions of the documentation have links to these files at their hosted locations on Colab. This commit restores those files to Colab.

In the future, we'll use version-specific links to the Colab notebooks. For 2.3 and earlier, readers will get the latest version available on Colab (usually 2.3).

All files are the 2.3 version, except for these two which are 2.2 editions (no newer version exists under these names):

- RIME_Bias_and_Fairness_Walkthrough_Lending.ipynb (in 2.3 it became RIME_Lending_Classification_Walkthrough.ipynb )
- RIME_Firewall_Configuring.ipynb (in 2.3 it became RIME_Continuous_Test_Configuring.ipynb )

Fixes issue DOCS-381
