### PR TITLE
Add a duplicate of the fraud demo notebook under its old name

### DIFF
--- a/notebooks/demo_notebooks/RIME_Fraud_OnboardingWalkthrough.ipynb
+++ b/notebooks/demo_notebooks/RIME_Fraud_OnboardingWalkthrough.ipynb
@@ -1,0 +1,1107 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "K05kWwxAT9uN",
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "# **RI Fraud Classification Walkthrough**\n",
+    "\n",
+    "> ▶️ **Try this in Colab!** Run the [RI Fraud Classification Walkthrough in Google Colab](https://colab.research.google.com/github/RobustIntelligence/docs/blob/2.6-stable/notebooks/demo_notebooks/RI_Fraud_Classification_Walkthrough.ipynb). \n",
+    "\n",
+    "You are a data scientist at a Payment Processing Company. The data science team has been tasked with implementing a Fraud Detection model and monitoring how that model performs over time. The performance of this fraud detection model directly impacts the costs of the company. In order to ensure the data science team develops the best model and the performance of this model doesn't degrade over time, the VP of Data Science purchases the RIME platform. \n",
+    "    \n",
+    "\n",
+    "In this Notebook Walkthrough, we will walkthrough 2 of RIME's core products - **AI Stress Testing** and **AI Continuous Testing**.\n",
+    "\n",
+    "1. **AI Stress Testing** is used in the model development stage. Using AI Stress Testing you can test the developed model. RIME goes beyond simply optimizing for basic model performance like accuracy and automatically discovers the model's weaknesses.\n",
+    "2. **AI Continuous Testing** is used after the model is deployed in production. Using AI Continuous Testing, you can automate the monitoring, discovery and remediation of issues that occur post-deployment."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "APMTB6F7byjr",
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "## **Install Dependencies, Import Libraries and Download Data**\n",
+    "Run the cell below to install libraries to receive data, install our SDK, and load analysis libraries."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "-Qr8pHVOcNz7",
+    "pycharm": {
+     "name": "#%%\n"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "!pip install rime-sdk &> /dev/null\n",
+    "\n",
+    "import pandas as pd\n",
+    "from pathlib import Path\n",
+    "from rime_sdk import Client\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "yxskvoMfcUl_",
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "!pip install https://github.com/RobustIntelligence/ri-public-examples/archive/master.zip\n",
+    "    \n",
+    "from ri_public_examples.download_files import download_files\n",
+    "\n",
+    "download_files('tabular-2.0/fraud', 'fraud')\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "90zo7hdkmKyW",
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "## **Establish the RIME Client**\n",
+    "\n",
+    "To get started, provide the API credentials and the base domain/address of the RIME service. You can generate and copy an API token from the API Access Tokens Page under Workspace settings. For the domian/address of the RIME service, contact your admin. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "90zo7hdkmKyW",
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "![Image of getting an API token](https://ri-documentation-public-release-images.s3.us-west-2.amazonaws.com/en/2.6-stable/_static/images/demo_notebooks/common/api_access_tokens.png)",
+    "![Image of creating an API token](https://ri-documentation-public-release-images.s3.us-west-2.amazonaws.com/en/2.6-stable/_static/images/demo_notebooks/common/create_token.png)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "Ns6m8I-qsCzF",
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "API_TOKEN = '' # PASTE API_KEY \n",
+    "CLUSTER_URL = '' # PASTE DEDICATED DOMAIN OF RIME SERVICE (eg: rime.stable.rbst.io)\n",
+    "AGENT_ID = '' # PASTE AGENT_ID IF USING AN AGENT THAT IS NOT THE DEFAULT\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "client = Client(CLUSTER_URL, API_TOKEN)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "pIjQx9KUvWCF",
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "## **Create a New Project**\n",
+    "\n",
+    "You can create projects in RIME to organize your test runs. Each project represents a workspace for a given machine learning task. It can contain multiple candidate models, but should only contain one promoted production model.  "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "YEghhVY8vy6K",
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "description = (\n",
+    "    \"Run Stress Testing and Continuous Testing on a tabular\"\n",
+    "    \" binary classification model and dataset. Demonstration uses a\"\n",
+    "    \" dataset that simulates credit card fraud detection.\"\n",
+    ")\n",
+    "project = client.create_project(\n",
+    "    name='Tabular Binary Classification Demo', \n",
+    "    description=description, \n",
+    "    model_task='MODEL_TASK_BINARY_CLASSIFICATION'\n",
+    ")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "eXZ6e7kiTit6",
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "**Go back to the UI to see the new Fraud Demo Project.**"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "3lsxeLehwN7Y",
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "## **Uploading the Model + Datasets**\n",
+    "\n",
+    "Let's first take a look at what the dataset looks like:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "rS6ST9KhZPEp",
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "df = pd.read_csv(Path('fraud/data/fraud_ref.csv'))\n",
+    "df.head()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "6Mbokt95ZPfe",
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "For this demo, we are going to use a pretrained CatBoostClassifier Model. \n",
+    "\n",
+    "The model predicts whether a particular transaction is fraud or not fraud.\n",
+    "\n",
+    "The model makes use of the following features - \n",
+    "\n",
+    "1.   category\n",
+    "2.   card_type\n",
+    "3.   card_company\n",
+    "4.   transaction_amount\n",
+    "5.   browser_version\n",
+    "6.   city\n",
+    "7.   country\n",
+    "\n",
+    "\n",
+    "We now want to kick off RIME Stress Tests that will help us evaluate the model in further depth beyond basic performance metrics like accuracy, precision, recall. In order to do this, we will upload this pre-trained model, the reference dataset the model was trained on, and the evaluation dataset the model was evaluated on to an S3 bucket that can be accessed by RIME."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "U1mcyn9JwdWQ",
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "upload_path = \"ri_public_examples_fraud\"\n",
+    "\n",
+    "model_s3_dir = client.upload_directory(\n",
+    "    Path('fraud/models'), upload_path=upload_path\n",
+    ")\n",
+    "model_s3_path = model_s3_dir + \"/fraud_model.py\"\n",
+    "\n",
+    "ref_s3_path = client.upload_file(\n",
+    "    Path('fraud/data/fraud_ref.csv'), upload_path=upload_path\n",
+    ")\n",
+    "eval_s3_path = client.upload_file(\n",
+    "    Path('fraud/data/fraud_eval.csv'), upload_path=upload_path\n",
+    ")\n",
+    "\n",
+    "ref_preds_s3_path = client.upload_file(\n",
+    "    Path(\"fraud/data/fraud_ref_preds.csv\"), upload_path=upload_path\n",
+    ")\n",
+    "eval_preds_s3_path = client.upload_file(\n",
+    "    Path(\"fraud/data/fraud_eval_preds.csv\"), upload_path=upload_path\n",
+    ")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "Once the data and model are uploaded to S3, we can register them to RIME. Once they're registered, we can refer to these resources using their RIME-generated ID's."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "from datetime import datetime\n",
+    "\n",
+    "dt = str(datetime.now())\n",
+    "\n",
+    "# Note: models and datasets need to have unique names.\n",
+    "model_id = project.register_model_from_path(f\"model_{dt}\", model_s3_path, agent_id=AGENT_ID)\n",
+    "\n",
+    "ref_dataset_id = project.register_dataset_from_file(\n",
+    "    f\"ref_dataset_{dt}\", ref_s3_path, data_params={\"label_col\": \"label\"}, agent_id=AGENT_ID\n",
+    ")\n",
+    "eval_dataset_id = project.register_dataset_from_file(\n",
+    "    f\"eval_dataset_{dt}\", eval_s3_path, data_params={\"label_col\": \"label\"}, agent_id=AGENT_ID\n",
+    ")\n",
+    "\n",
+    "project.register_predictions_from_file(\n",
+    "    ref_dataset_id, model_id, ref_preds_s3_path, agent_id=AGENT_ID\n",
+    ")\n",
+    "project.register_predictions_from_file(\n",
+    "    eval_dataset_id, model_id, eval_preds_s3_path, agent_id=AGENT_ID\n",
+    ")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "yCasNMsy0Avt",
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "## **Running a Stress Test**\n",
+    "\n",
+    "AI Stress Tests allow you to test your data and model before deployment. They are a comprehensive suite of hundreds of tests that automatically identify implicit assumptions and weaknesses of pre-production models. Each stress test is run on a single model and its associated reference and evaluation datasets. \n",
+    "\n",
+    "Below is a sample configuration of how to setup and run a RIME Stress Test."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "MA-mVn3pzVA1",
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "stress_test_config = {\n",
+    "    \"run_name\": \"Onboarding Stress Test Run\", \n",
+    "    \"data_info\": {\n",
+    "        \"ref_dataset_id\": ref_dataset_id, \n",
+    "        \"eval_dataset_id\": eval_dataset_id,\n",
+    "    }, \n",
+    "    \"model_id\": model_id,\n",
+    "    \"categories\": [\n",
+    "            \"TEST_CATEGORY_TYPE_ADVERSARIAL\",\n",
+    "            \"TEST_CATEGORY_TYPE_SUBSET_PERFORMANCE\",\n",
+    "            \"TEST_CATEGORY_TYPE_TRANSFORMATIONS\",\n",
+    "            \"TEST_CATEGORY_TYPE_ABNORMAL_INPUTS\",\n",
+    "            \"TEST_CATEGORY_TYPE_DATA_CLEANLINESS\"]\n",
+    "}\n",
+    "stress_job = client.start_stress_test(\n",
+    "    stress_test_config, project.project_id, agent_id=AGENT_ID\n",
+    ")\n",
+    "stress_job.get_status(verbose=True, wait_until_finish=True)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "LFB5nVEaTtnB",
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "**Wait for a couple minutes and your results will appear in the UI.**"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "ovrKDoifIxIm",
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "## **Stress Test Results**\n",
+    "\n",
+    "Stress tests are grouped first by risk categories and then into categories that measure various aspects of model robustness (model behavior, distribution drift, abnormal input, transformations, adversarial attacks, data cleanliness). Key findings to improve your model are aggregated on the category level as well. Tests are ranked by default by a shared severity metric. Clicking on an individual test surfaces more detailed information. \n",
+    "\n",
+    "\n",
+    "You can view the detailed results in the UI by running the below cell and redirecting to the generated link. This page shows granular results for a given AI Stress Test run. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "h2iYOcGiI16-",
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "test_run = stress_job.get_test_run()\n",
+    "test_run\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "1zKDo7TOYYds",
+    "pycharm": {
+     "name": "#%% md\n"
+    },
+    "tags": []
+   },
+   "source": [
+    "### **Analyzing the Results**\n",
+    "\n",
+    "Below you can see a snapshot of the results. \n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "h2jQYUDmknsU",
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "![Image of a stress test results for a fraud detection model](https://ri-documentation-public-release-images.s3.us-west-2.amazonaws.com/en/2.6-stable/_static/images/demo_notebooks/ri_fraud_classification_walkthrough/fraud_st_results.png)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "1oO26DNFoJQV",
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "Here are the results of one of the Operational Risk tests, Transformations. Transformation tests augment evaluation dataset with abnormal values and measure the performance degradation from them."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "Nc1TzYeqkn1k",
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "![Image of transformation test results for a fraud detection model](https://ri-documentation-public-release-images.s3.us-west-2.amazonaws.com/en/2.6-stable/_static/images/demo_notebooks/ri_fraud_classification_walkthrough/fraud_transformation.png)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "EfnKH70fpmmu",
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "Below we are exploring the \"Capitalization Change\" test cases for the feature \"category\". This test measures the impact on the model when we substitute different types of capitalization into clean datapoints."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "g91I82zRkoH5",
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "![Image of capitalization-change test result for a fraud detection model](https://ri-documentation-public-release-images.s3.us-west-2.amazonaws.com/en/2.6-stable/_static/images/demo_notebooks/ri_fraud_classification_walkthrough/fraud_capitalization.png)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "XGivw_Weookf",
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "### **Programmatically Querying the Results**"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "HB4A2GouWysL",
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "RIME not only provides you with an intuitive UI to visualize and explore these results, but also allows you to programmatically query these results. This allows customers to integrate with their MLOps pipeline, log results to experiment management tools like MLFlow, bring automated decision making to their ML practicies, or store these results for future references. \n",
+    "\n",
+    "Run the below cell to programmatically query the results. The results are outputed as a pandas dataframe."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "fTWLakM8VQj6",
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "**Access results at the a test run overview level**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "dgawCIZWLFST",
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "test_run_result = test_run.get_result_df()\n",
+    "test_run_result\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "tUUcNh7XVUPl",
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "**Access detailed test results at each individual test cases level.**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "u2qh2linVIt9",
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "test_case_result = test_run.get_test_cases_df()\n",
+    "test_case_result.head()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "5f7LPX1pqOhP",
+    "pycharm": {
+     "name": "#%% md\n"
+    },
+    "tags": []
+   },
+   "source": [
+    "## **Deploy to Production and set up Continuous Testing**\n",
+    "\n",
+    "Once you have identified the best stress test run, you can deploy the associated model and set up Continuous Testing in order to automatically detect “bad” incoming data and statistically significant distributional drift. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "from datetime import timedelta\n",
+    "\n",
+    "project.update_ct_categories([\"TEST_CATEGORY_TYPE_ABNORMAL_INPUTS\",\n",
+    "                              \"TEST_CATEGORY_TYPE_DRIFT\",\n",
+    "                              \"TEST_CATEGORY_TYPE_EVASION_ATTACK_DETECTION\"\n",
+    "                            ])\n",
+    "\n",
+    "ct_instance = project.create_ct(model_id, ref_dataset_id, timedelta(days=1))\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "a0Lw2YBXBkb4",
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "## **Uploading a Batch of Production Data & Model Predictions to Continuous Testing**\n",
+    "\n",
+    "The fraud detection model has been in production for 30 days. Production data and model predictions have been collected and stored for the past 30 days. Now, we will use Continuous Testing to track how the model performed across the last 30 days. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "g7McYwfDUztC",
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "**Upload the Latest Batch of Production Data**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "zsmlbMIFUzAy",
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "dt = str(datetime.now())\n",
+    "prod_s3_path = client.upload_file(\n",
+    "    Path('fraud/data/fraud_incremental.csv'), \n",
+    "    upload_path=upload_path\n",
+    ")\n",
+    "prod_dataset_id = project.register_dataset_from_file(\n",
+    "    f\"prod_dataset_{dt}\", \n",
+    "    prod_s3_path, \n",
+    "    data_params={\"label_col\": \"label\", \"timestamp_col\": \"timestamp\"},\n",
+    "    agent_id=AGENT_ID\n",
+    ")\n",
+    "prod_preds_s3_path = client.upload_file(\n",
+    "    Path('fraud/data/fraud_incremental_preds.csv'), \n",
+    "    upload_path=upload_path\n",
+    ")\n",
+    "project.register_predictions_from_file(\n",
+    "    prod_dataset_id, model_id, prod_preds_s3_path, agent_id=AGENT_ID\n",
+    ")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "e-ooaBT-U4yr",
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "**Run Continuous Testing over Batch of Data**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "EHxteK1gUklo",
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "ct_job = ct_instance.start_continuous_test(prod_dataset_id, agent_id=AGENT_ID)\n",
+    "ct_job.get_status(verbose=True, wait_until_finish=True)\n",
+    "ct_instance\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "ifxKz_p6Uc63",
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "**Wait for a couple minutes and your results will appear in the UI.**"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "## **Querying Results from Continuous Testing**"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "After continuous testing has been created and data has been uploaded for processing, the user can query the results throughout the entire uploaded history."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "**Obtain All Detection Events**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "events = [d.to_dict() for m in ct_instance.list_monitors() for d in m.list_detected_events()]\n",
+    "events_df = pd.DataFrame(events).drop([\"id\", \"project_id\", \"firewall_id\", \"event_object_id\", \"description_html\", \"last_update_time\"], axis=1)\n",
+    "events_df.head()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "vmpxUnaLMn-u",
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "\n",
+    "## **CT Overview**\n",
+    "\n",
+    "The Overview page is the mission control for your model’s production deployment health. In it, you can see the status of continuous test runs and their metrics change over time.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "AFuGGg8uNtC2",
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "![Image of a graph of the historic performance results for a fraud detection model](https://ri-documentation-public-release-images.s3.us-west-2.amazonaws.com/en/2.6-stable/_static/images/demo_notebooks/ri_fraud_classification_walkthrough/fraud_historical.png)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "MzMea8BUFOT1",
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "## **CT Results**\n",
+    "\n",
+    "The Continuous Tests operate at the batch level and provide a mechanism to monitor the health of ML deployments in production. They allow the user to understand when errors begin to occur and surface the underlying drivers of such errors. \n",
+    "\n",
+    "You can explore the results in the UI by running the below cell and redirecting to the generated link.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "Qndn2zUMLhJo",
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "ct_instance\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "## **Appendix**"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "## **Uploading a Model to RIME**\n",
+    "To be able to run certain tests, RIME needs query access to your model. To give RIME access, you'll need to write a Python file that implements the `predict_df(df: pd.DataFrame) -> np.ndarray` function, and upload that file (and any objects that it loads) to the platform. Here we provide an example model file, show you how to upload this file and the relevant model artifacts, and show you how to configure stress tests to use this model."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "%%writefile fraud/models/fraud_model.py\n",
+    "from pathlib import Path\n",
+    "\n",
+    "from catboost import CatBoostClassifier\n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "\n",
+    "\n",
+    "mod = CatBoostClassifier()\n",
+    "# Load our CatBoost model. Note that this requires us to\n",
+    "# upload fraud_model.catb along with this Python file,\n",
+    "# in the same directory.\n",
+    "mod.load_model(Path(__file__).parent / \"fraud_model.catb\")\n",
+    "cat_cols = [\n",
+    "    'category', \n",
+    "    'card_type', \n",
+    "    'card_company', \n",
+    "    'city', \n",
+    "    'browser_version', \n",
+    "    'country',\n",
+    "]\n",
+    "\n",
+    "def predict_df(df: pd.DataFrame) -> np.ndarray:\n",
+    "    \"\"\"Given data as a pandas DataFrame, return probabilities as a NumPy array.\"\"\"\n",
+    "    for col in cat_cols:\n",
+    "        df[col] = df[col].astype(object)\n",
+    "    # For binary classification we expect a one-dimensional\n",
+    "    # array for the probabilities, where the score for each datapoint\n",
+    "    # is the probability that the label is 1.\n",
+    "    return mod.predict_proba(df.fillna(0))[:,1]\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Note that 'fraud/models' directory already contains the 'fraud_model.catb' file.\n",
+    "appendix_model_dir = client.upload_directory(\n",
+    "    Path('fraud/models'), upload_path=upload_path\n",
+    ")\n",
+    "appendix_model_path = appendix_model_dir + \"/fraud_model.py\"\n",
+    "appendix_model_id = project.register_model_from_path(\n",
+    "    f\"appendix_model_{dt}\", appendix_model_path\n",
+    ")\n",
+    "stress_test_with_model_config = {\n",
+    "    \"run_name\": \"Uploaded Model Example\",\n",
+    "    \"data_info\": {\n",
+    "        \"ref_dataset_id\": ref_dataset_id, \n",
+    "        \"eval_dataset_id\": eval_dataset_id,\n",
+    "    },\n",
+    "    \"model_id\": appendix_model_id\n",
+    "}\n",
+    "stress_job = client.start_stress_test(\n",
+    "    stress_test_with_model_config, project.project_id, agent_id=AGENT_ID\n",
+    ")\n",
+    "stress_job.get_status(verbose=True, wait_until_finish=True)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "## **Running a Custom Test**\n",
+    "With RIME you can write your own custom tests, to encode any domain-specific validation you want to perform. These tests will run and be uploaded to the platform just like any of the built-in tests. To run a custom test you need to implement a specific interface in Python, upload the file to the platform, and point to it in your configuration. Below we provide a simple example of a custom test that checks if the difference in the length of the reference and evaluation datasets does not exceed some threshold."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "%%writefile fraud/custom_test.py\n",
+    "\"\"\"Custom test batch runner.\"\"\"\n",
+    "from typing import List, Tuple\n",
+    "from rime.core.schema.config import CustomConfig\n",
+    "from rime.protos.ri.api.resultsynthesizer.result_message_pb2 import (\n",
+    "    TestCaseStatus as Status,\n",
+    ")\n",
+    "from rime.core.stress_tests.schema.table_info import TableColumn\n",
+    "from rime.core.stress_tests.schema.test_result import TestBatchResult, TestOutput\n",
+    "from rime.core.test import BaseTest, TestExtraInfo\n",
+    "from rime.core.stress_tests.batch_runner import DataTestBatchRunner\n",
+    "from rime.core.stress_tests.schema.test_result import TestBatchResult, TestOutput\n",
+    "from rime.core.profiler.run_containers import RunContainer\n",
+    "from rime.protos.ri.lib.common_pb2 import Severity\n",
+    "\n",
+    "# Signature should not be changed.\n",
+    "class CustomTest(BaseTest):\n",
+    "    def __init__(self, delta: int = 0):\n",
+    "        \"\"\"Initialize with a delta between n_rows ref and eval.\"\"\"\n",
+    "        super().__init__()\n",
+    "        self.delta = delta\n",
+    "\n",
+    "    # Signature should not be changed.\n",
+    "    def run(\n",
+    "        self, \n",
+    "        run_container: RunContainer,\n",
+    "        silent_errors: bool = False\n",
+    "    ) -> Tuple[TestOutput, TestExtraInfo]:\n",
+    "        ref_data_size = len(run_container.ref_data.df)\n",
+    "        eval_data_size = len(run_container.eval_data.df)\n",
+    "        if ref_data_size > eval_data_size + self.delta:\n",
+    "            status = Status.TEST_CASE_STATUS_WARNING\n",
+    "            severity = Severity.SEVERITY_ALERT\n",
+    "        else:\n",
+    "            status = Status.TEST_CASE_STATUS_PASS_UNSPECIFIED\n",
+    "            severity = Severity.SEVERITY_PASS\n",
+    "        test_output = TestOutput(\n",
+    "            self.id, status, {\"Severity\": severity}, severity, [],\n",
+    "        )\n",
+    "        return test_output, TestExtraInfo(severity)\n",
+    "\n",
+    "\n",
+    "# Signature should not be changed.\n",
+    "class CustomBatchRunner(DataTestBatchRunner):\n",
+    "    \"\"\"TestBatchRunner for the CustomTest.\"\"\"\n",
+    "\n",
+    "    # Signature should not be changed.\n",
+    "    @classmethod\n",
+    "    def _from_config(\n",
+    "        cls, run_container: RunContainer,  config: CustomConfig, category: str\n",
+    "    ) -> \"DataTestBatchRunner\":\n",
+    "        if config.params is None:\n",
+    "            delta = 0\n",
+    "        else:\n",
+    "            delta = config.params[\"delta\"]\n",
+    "        tests = [CustomTest(delta=delta)]\n",
+    "        return cls(tests, category)\n",
+    "\n",
+    "    # Signature should not be changed.\n",
+    "    def _outputs_to_batch_res(\n",
+    "        self,\n",
+    "        run_container: RunContainer,\n",
+    "        outputs: List[TestOutput],\n",
+    "        extra_infos: List[dict],\n",
+    "        duration: float,\n",
+    "    ) -> TestBatchResult:\n",
+    "        long_description_tabs = [\n",
+    "            {\"title\": \"Description\", \"contents\": self.long_description},\n",
+    "            {\"title\": \"Why it Matters\", \"contents\": \"Explain why this test matters.\"},\n",
+    "            {\n",
+    "                \"title\": \"Configuration\",\n",
+    "                \"contents\": \"Explain how this test is configured.\"\n",
+    "            },\n",
+    "            {\n",
+    "                \"title\": \"Example\",\n",
+    "                \"contents\": \"Include an example of how this test works.\"\n",
+    "            },\n",
+    "        ]\n",
+    "        return TestBatchResult(\n",
+    "            self.type,\n",
+    "            self.description,\n",
+    "            long_description_tabs,\n",
+    "            self.category,\n",
+    "            outputs,\n",
+    "            [],\n",
+    "            duration,\n",
+    "            extra_infos,\n",
+    "            [TableColumn(\"Severity\")],\n",
+    "            outputs[0].severity,\n",
+    "        )\n",
+    "\n",
+    "\n",
+    "    # Signature should not be changed.\n",
+    "    @property\n",
+    "    def description(self) -> str:\n",
+    "        return \"This is custom test\"\n",
+    "\n",
+    "    # Signature should not be changed.\n",
+    "    @property\n",
+    "    def long_description(self) -> str:\n",
+    "        return \"This is a long description of a custom test.\"\n",
+    "\n",
+    "    # Signature should not be changed.\n",
+    "    @property\n",
+    "    def type(self) -> str:\n",
+    "        return \"Example Custom Test\"\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "custom_test_path = client.upload_file(\"fraud/custom_test.py\", upload_path=upload_path)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "stress_test_with_model_config = {\n",
+    "    \"run_name\": \"Custom Test Example\",\n",
+    "    \"data_info\": {\n",
+    "        \"ref_dataset_id\": ref_dataset_id, \n",
+    "        \"eval_dataset_id\": eval_dataset_id,\n",
+    "    },\n",
+    "    \"test_suite_config\": {\n",
+    "        \"custom_tests\": [\n",
+    "            {\n",
+    "                \"custom_test_category\": \"Data Cleanliness\", \n",
+    "                \"test_path\": custom_test_path\n",
+    "            }\n",
+    "        ],\n",
+    "    },\n",
+    "    \"model_id\": model_id\n",
+    "}\n",
+    "stress_job = client.start_stress_test(\n",
+    "    stress_test_with_model_config, project.project_id, agent_id=AGENT_ID\n",
+    ")\n",
+    "stress_job.get_status(verbose=True, wait_until_finish=True)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "stress_job.get_test_run()\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "colab": {
+   "collapsed_sections": [],
+   "name": "RI_Fraud_Classification_Walkthrough.ipynb",
+   "provenance": []
+  },
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
Fixes issue DOCS-471.

Background is that the notebook, RIME_Fraud_OnboardingWalkthrough.ipynb was renamed to RI_Fraud_Classification_Walkthrough.ipynb in 2.4, but we failed to update the link in
web/rime-frontend/src/components/layouts/navbar/Sidebar/OnboardingModal/index.tsx

This change just adds the notebook under the old name, so older control planes' links will work again.